### PR TITLE
Adds GraphQL client for Payments Apps

### DIFF
--- a/.changeset/small-dryers-cover.md
+++ b/.changeset/small-dryers-cover.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Adds GraphQL client to support `/payments_apps/api` endpoint. See https://shopify.dev/api/payments-apps/ for more details.

--- a/lib/clients/graphql/__tests__/payments_apps_client.test.ts
+++ b/lib/clients/graphql/__tests__/payments_apps_client.test.ts
@@ -1,0 +1,75 @@
+import {shopify, queueMockResponse} from '../../../__tests__/test-helper';
+import {Session} from '../../../session/session';
+import {JwtPayload} from '../../../session/types';
+
+const domain = 'test-shop.myshopify.io';
+const QUERY = `
+{
+  shop {
+    name
+  }
+}
+`;
+
+const successResponse = {
+  data: {
+    shop: {
+      name: 'Shoppity Shop',
+    },
+  },
+};
+
+const accessToken = 'dangit';
+let session: Session;
+let jwtPayload: JwtPayload;
+
+describe('Payments Apps GraphQL client', () => {
+  beforeEach(() => {
+    jwtPayload = {
+      iss: 'https://test-shop.myshopify.io/admin',
+      dest: 'https://test-shop.myshopify.io',
+      aud: shopify.config.apiKey,
+      sub: '1',
+      exp: Date.now() / 1000 + 3600,
+      nbf: 1234,
+      iat: 1234,
+      jti: '4321',
+      sid: 'abc123',
+    };
+
+    session = new Session({
+      id: `test-shop.myshopify.io_${jwtPayload.sub}`,
+      shop: domain,
+      state: 'state',
+      isOnline: true,
+      accessToken,
+    });
+  });
+
+  it('can return response from specific access token', async () => {
+    const client = new shopify.clients.PaymentsApps({session});
+
+    queueMockResponse(JSON.stringify(successResponse));
+
+    await expect(client.query({data: QUERY})).resolves.toEqual(
+      buildExpectedResponse(successResponse),
+    );
+
+    const headers: {[key: string]: unknown} = {};
+    expect({
+      method: 'POST',
+      domain,
+      path: `/payments_apps/api/${shopify.config.apiVersion}/graphql.json`,
+      data: QUERY,
+      headers,
+    }).toMatchMadeHttpRequest();
+  });
+});
+
+function buildExpectedResponse(obj: unknown) {
+  const expectedResponse = {
+    body: obj,
+    headers: expect.objectContaining({}),
+  };
+  return expect.objectContaining(expectedResponse);
+}

--- a/lib/clients/graphql/payments_apps_client.ts
+++ b/lib/clients/graphql/payments_apps_client.ts
@@ -1,0 +1,30 @@
+import {httpClientClass} from '../http_client/http_client';
+
+import {GraphqlClient, GraphqlClientClassParams} from './graphql_client';
+import {PaymentsAppsClientParams} from './types';
+
+export class PaymentsAppsClient extends GraphqlClient {
+  baseApiPath = '/payments_apps/api';
+
+  constructor(params: PaymentsAppsClientParams) {
+    super(params);
+  }
+}
+
+export function paymentsAppsClientClass(params: GraphqlClientClassParams) {
+  const {config} = params;
+  let {HttpClient} = params;
+  if (!HttpClient) {
+    HttpClient = httpClientClass(config);
+  }
+  class NewPaymentsAppsClient extends PaymentsAppsClient {
+    public static config = config;
+    public static HttpClient = HttpClient!;
+  }
+
+  Reflect.defineProperty(NewPaymentsAppsClient, 'name', {
+    value: 'PaymentsAppsClient',
+  });
+
+  return NewPaymentsAppsClient as typeof PaymentsAppsClient;
+}

--- a/lib/clients/graphql/types.ts
+++ b/lib/clients/graphql/types.ts
@@ -9,10 +9,7 @@ export interface GraphqlClientParams {
   apiVersion?: ApiVersion;
 }
 
-export interface PaymentsAppsClientParams {
-  session: Session;
-  apiVersion?: ApiVersion;
-}
+export interface PaymentsAppsClientParams extends GraphqlClientParams {}
 
 export interface StorefrontClientParams {
   domain: string;

--- a/lib/clients/graphql/types.ts
+++ b/lib/clients/graphql/types.ts
@@ -9,6 +9,11 @@ export interface GraphqlClientParams {
   apiVersion?: ApiVersion;
 }
 
+export interface PaymentsAppsClientParams {
+  session: Session;
+  apiVersion?: ApiVersion;
+}
+
 export interface StorefrontClientParams {
   domain: string;
   storefrontAccessToken: string;

--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -4,6 +4,7 @@ import {httpClientClass} from './http_client/http_client';
 import {restClientClass} from './rest/rest_client';
 import {graphqlClientClass} from './graphql/graphql_client';
 import {storefrontClientClass} from './graphql/storefront_client';
+import {paymentsAppsClientClass} from './graphql/payments_apps_client';
 import {graphqlProxy} from './graphql/graphql_proxy';
 
 export function clientClasses(config: ConfigInterface) {
@@ -12,6 +13,7 @@ export function clientClasses(config: ConfigInterface) {
     // We don't pass in the HttpClient because the RestClient inherits from it, and goes through the same setup process
     Rest: restClientClass({config}),
     Graphql: graphqlClientClass({config, HttpClient}),
+    PaymentsApps: paymentsAppsClientClass({config, HttpClient}),
     Storefront: storefrontClientClass({config, HttpClient}),
     graphqlProxy: graphqlProxy(config),
   };


### PR DESCRIPTION
### WHY are these changes introduced?

Adds client to support /payments_apps/api endpoint.
See https://shopify.dev/api/payments-apps/

Port of PR #454.

### WHAT is this pull request doing?

Adds a GraphQL client for supporting the Payments Apps endpoint, similar to Storefront Client.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
