### PR TITLE
Export deprecation notices for v5 main interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - [Patch] Raise an `InvalidSession` if `Session.fromPropertyArray` receive an object that is not an array
 - [Patch] Validate content of host parameter using sanitizeShop regex [#634](https://github.com/Shopify/shopify-api-js/pull/634)
 - [Patch] Use the GraphQL format of webhook topics in the error message [#626](https://github.com/Shopify/shopify-api-js/pull/626)
+- [Patch] Export deprecation notices for v5 main interface [#639](https://github.com/Shopify/shopify-api-js/pull/639)
 
 ## [6.0.1] - 2022-12-08
 

--- a/lib/deprecated-v5-types.ts
+++ b/lib/deprecated-v5-types.ts
@@ -1,0 +1,65 @@
+export interface DeprecatedV5Types {
+  /**
+   * @deprecated
+   * `Shopify.Context` is now `Shopify.config` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md
+   */
+  Context?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Auth` is now `Shopify.auth` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-authentication-functions
+   */
+  Auth?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Billing` is now `Shopify.billing` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#billing
+   */
+  Billing?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Session` is now `Shopify.session` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-session-and-sessionstorage
+   */
+  Session?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Clients` is now `Shopify.clients` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-api-clients
+   */
+  Clients?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Utils` is now `Shopify.utils` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#utility-functions
+   */
+  Utils?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Webhooks` is now `Shopify.webhooks` and its API has changed.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-webhook-functions
+   */
+  Webhooks?: never;
+
+  /**
+   * @deprecated
+   * `Shopify.Errors` was deprecated, error classes are now exported directly from the package.
+   *
+   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#simplified-namespace-for-errors
+   */
+  Errors?: never;
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 import {loadRestResources} from '../rest/load-rest-resources';
 import {ShopifyRestResources} from '../rest/types';
 
+import {DeprecatedV5Types} from './deprecated-v5-types';
 import {ConfigParams, ConfigInterface} from './base-types';
 import {validateConfig} from './config';
 import {clientClasses, ShopifyClients} from './clients';
@@ -20,6 +21,10 @@ export * from './base-types';
 export * from './session/types';
 export * from './auth/types';
 export * from './webhooks/types';
+
+// Temporarily export the deprecated v5 types as a Shopify object (as opposed to the type above) to help folks find
+// the migration guide.
+export const Shopify: DeprecatedV5Types = {};
 
 export interface Shopify<
   T extends ShopifyRestResources = ShopifyRestResources,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes https://github.com/Shopify/first-party-library-planning/issues/517

The differences between v5 and v6 of this library are very extensive. In order to meet developers closer to where they are when migrating, we should make it easy for them to find the migration instructions directly from their IDE.

### WHAT is this pull request doing?

Exporting an interface that replicates the previous version's main exports, which point the user toward the appropriate section of the migration guide.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above

cc @developit 