### PR TITLE
Add SDK headers to SF API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - [Patch] Don't ignore previous headers when beginning OAuth [#652](https://github.com/Shopify/shopify-api-js/pull/652)
 - [Patch] Export missing client types from package [#648](https://github.com/Shopify/shopify-api-js/pull/648)
 - [Patch] Add an info-level log of API library version and runtime environment string during initialization, to aid in troubleshooting [650](https://github.com/Shopify/shopify-api-js/pull/650)
+- [Patch] Add new tracking SDK headers to Storefront API client [#649](https://github.com/Shopify/shopify-api-js/pull/649)
 
 ## [6.0.2] - 2022-12-08
 

--- a/lib/clients/graphql/__tests__/storefront_client.test.ts
+++ b/lib/clients/graphql/__tests__/storefront_client.test.ts
@@ -1,5 +1,5 @@
 import {shopify, queueMockResponse} from '../../../__tests__/test-helper';
-import {ShopifyHeader} from '../../../types';
+import {LIBRARY_NAME, ShopifyHeader} from '../../../types';
 import {Session} from '../../../session/session';
 import {JwtPayload} from '../../../session/types';
 import {SHOPIFY_API_LIBRARY_VERSION} from '../../../version';
@@ -115,7 +115,7 @@ describe('Storefront GraphQL client', () => {
       data: QUERY,
       headers: {
         [ShopifyHeader.StorefrontAccessToken]: storefrontAccessToken,
-        [ShopifyHeader.StorefrontSDKVariant]: '@shopify/shopify-api',
+        [ShopifyHeader.StorefrontSDKVariant]: LIBRARY_NAME,
         [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
       },
     }).toMatchMadeHttpRequest();

--- a/lib/clients/graphql/__tests__/storefront_client.test.ts
+++ b/lib/clients/graphql/__tests__/storefront_client.test.ts
@@ -1,5 +1,5 @@
 import {shopify, queueMockResponse} from '../../../__tests__/test-helper';
-import {LIBRARY_NAME, ShopifyHeader} from '../../../types';
+import {ShopifyHeader} from '../../../types';
 import {Session} from '../../../session/session';
 import {JwtPayload} from '../../../session/types';
 import {SHOPIFY_API_LIBRARY_VERSION} from '../../../version';
@@ -115,7 +115,7 @@ describe('Storefront GraphQL client', () => {
       data: QUERY,
       headers: {
         [ShopifyHeader.StorefrontAccessToken]: storefrontAccessToken,
-        [ShopifyHeader.StorefrontSDKVariant]: LIBRARY_NAME,
+        [ShopifyHeader.StorefrontSDKVariant]: 'shopify-api-library',
         [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
       },
     }).toMatchMadeHttpRequest();

--- a/lib/clients/graphql/graphql_client.ts
+++ b/lib/clients/graphql/graphql_client.ts
@@ -1,7 +1,7 @@
 import {ShopifyHeader} from '../../types';
 import {ConfigInterface} from '../../base-types';
 import {httpClientClass, HttpClient} from '../http_client/http_client';
-import {DataType, RequestReturn} from '../http_client/types';
+import {DataType, HeaderParams, RequestReturn} from '../http_client/types';
 import {Session} from '../../session/session';
 import * as ShopifyErrors from '../../error';
 
@@ -10,11 +10,6 @@ import {GraphqlParams, GraphqlClientParams} from './types';
 export interface GraphqlClientClassParams {
   config: ConfigInterface;
   HttpClient?: typeof HttpClient;
-}
-
-export interface AccessTokenHeader {
-  header: string;
-  value: string;
 }
 
 export class GraphqlClient {
@@ -51,11 +46,8 @@ export class GraphqlClient {
       throw new ShopifyErrors.MissingRequiredArgument('Query missing.');
     }
 
-    const accessTokenHeader = this.getAccessTokenHeader();
-    params.extraHeaders = {
-      [accessTokenHeader.header]: accessTokenHeader.value,
-      ...params.extraHeaders,
-    };
+    const apiHeaders = this.getApiHeaders();
+    params.extraHeaders = {...apiHeaders, ...params.extraHeaders};
 
     const path = `${this.baseApiPath}/${
       this.graphqlClass().CONFIG.apiVersion
@@ -84,10 +76,9 @@ export class GraphqlClient {
     return result;
   }
 
-  protected getAccessTokenHeader(): AccessTokenHeader {
+  protected getApiHeaders(): HeaderParams {
     return {
-      header: ShopifyHeader.AccessToken,
-      value: this.graphqlClass().CONFIG.isPrivateApp
+      [ShopifyHeader.AccessToken]: this.graphqlClass().CONFIG.isPrivateApp
         ? this.graphqlClass().CONFIG.apiSecretKey
         : (this.session.accessToken as string),
     };

--- a/lib/clients/graphql/storefront_client.ts
+++ b/lib/clients/graphql/storefront_client.ts
@@ -1,5 +1,5 @@
 import {SHOPIFY_API_LIBRARY_VERSION} from '../../version';
-import {ShopifyHeader} from '../../types';
+import {LIBRARY_NAME, ShopifyHeader} from '../../types';
 import {httpClientClass} from '../http_client/http_client';
 import {Session} from '../../session/session';
 import {HeaderParams} from '../http_client/types';
@@ -32,7 +32,7 @@ export class StorefrontClient extends GraphqlClient {
         ? this.storefrontClass().CONFIG.privateAppStorefrontAccessToken ||
           this.storefrontAccessToken
         : this.storefrontAccessToken,
-      [ShopifyHeader.StorefrontSDKVariant]: '@shopify/shopify-api',
+      [ShopifyHeader.StorefrontSDKVariant]: LIBRARY_NAME,
       [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
     };
   }

--- a/lib/clients/graphql/storefront_client.ts
+++ b/lib/clients/graphql/storefront_client.ts
@@ -26,13 +26,15 @@ export class StorefrontClient extends GraphqlClient {
   }
 
   protected getApiHeaders(): HeaderParams {
+    const sdkVariant = LIBRARY_NAME.toLowerCase().split(' ').join('-');
+
     return {
       [ShopifyHeader.StorefrontAccessToken]: this.storefrontClass().CONFIG
         .isPrivateApp
         ? this.storefrontClass().CONFIG.privateAppStorefrontAccessToken ||
           this.storefrontAccessToken
         : this.storefrontAccessToken,
-      [ShopifyHeader.StorefrontSDKVariant]: LIBRARY_NAME,
+      [ShopifyHeader.StorefrontSDKVariant]: sdkVariant,
       [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
     };
   }

--- a/lib/clients/graphql/storefront_client.ts
+++ b/lib/clients/graphql/storefront_client.ts
@@ -1,12 +1,10 @@
+import {SHOPIFY_API_LIBRARY_VERSION} from '../../version';
 import {ShopifyHeader} from '../../types';
 import {httpClientClass} from '../http_client/http_client';
 import {Session} from '../../session/session';
+import {HeaderParams} from '../http_client/types';
 
-import {
-  AccessTokenHeader,
-  GraphqlClient,
-  GraphqlClientClassParams,
-} from './graphql_client';
+import {GraphqlClient, GraphqlClientClassParams} from './graphql_client';
 import {StorefrontClientParams} from './types';
 
 export class StorefrontClient extends GraphqlClient {
@@ -27,13 +25,15 @@ export class StorefrontClient extends GraphqlClient {
     this.storefrontAccessToken = params.storefrontAccessToken;
   }
 
-  protected getAccessTokenHeader(): AccessTokenHeader {
+  protected getApiHeaders(): HeaderParams {
     return {
-      header: ShopifyHeader.StorefrontAccessToken,
-      value: (this.storefrontClass().CONFIG.isPrivateApp
+      [ShopifyHeader.StorefrontAccessToken]: this.storefrontClass().CONFIG
+        .isPrivateApp
         ? this.storefrontClass().CONFIG.privateAppStorefrontAccessToken ||
           this.storefrontAccessToken
-        : this.storefrontAccessToken) as string,
+        : this.storefrontAccessToken,
+      [ShopifyHeader.StorefrontSDKVariant]: '@shopify/shopify-api',
+      [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
     };
   }
 

--- a/lib/clients/http_client/http_client.ts
+++ b/lib/clients/http_client/http_client.ts
@@ -1,6 +1,7 @@
 import {Method, StatusCode} from '@shopify/network';
 
 import * as ShopifyErrors from '../../error';
+import {LIBRARY_NAME} from '../../types';
 import {SHOPIFY_API_LIBRARY_VERSION} from '../../version';
 import ProcessedQuery from '../../utils/processed-query';
 import {ConfigInterface} from '../../base-types';
@@ -90,7 +91,7 @@ export class HttpClient {
       );
     }
 
-    let userAgent = `Shopify API Library v${SHOPIFY_API_LIBRARY_VERSION} | ${abstractRuntimeString()}`;
+    let userAgent = `${LIBRARY_NAME} v${SHOPIFY_API_LIBRARY_VERSION} | ${abstractRuntimeString()}`;
 
     if (this.httpClass().CONFIG.userAgentPrefix) {
       userAgent = `${this.httpClass().CONFIG.userAgentPrefix} | ${userAgent}`;

--- a/lib/clients/http_client/types.ts
+++ b/lib/clients/http_client/types.ts
@@ -6,11 +6,13 @@ export interface HeaderParams {
   [key: string]: string | number | string[];
 }
 
+/* eslint-disable @shopify/typescript/prefer-pascal-case-enums */
 export enum DataType {
-  JSON = 'application/json', // eslint-disable-line @shopify/typescript/prefer-pascal-case-enums
-  GraphQL = 'application/graphql', // eslint-disable-line @shopify/typescript/prefer-pascal-case-enums
-  URLEncoded = 'application/x-www-form-urlencoded', // eslint-disable-line @shopify/typescript/prefer-pascal-case-enums
+  JSON = 'application/json',
+  GraphQL = 'application/graphql',
+  URLEncoded = 'application/x-www-form-urlencoded',
 }
+/* eslint-enable @shopify/typescript/prefer-pascal-case-enums */
 
 export type QueryParams =
   | string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,6 +13,7 @@ export enum ApiVersion {
   Unstable = 'unstable',
 }
 
+export const LIBRARY_NAME = 'Shopify API Library';
 export const LATEST_API_VERSION = ApiVersion.October22;
 
 /* eslint-disable @shopify/typescript/prefer-pascal-case-enums */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -15,15 +15,19 @@ export enum ApiVersion {
 
 export const LATEST_API_VERSION = ApiVersion.October22;
 
+/* eslint-disable @shopify/typescript/prefer-pascal-case-enums */
 export enum ShopifyHeader {
   AccessToken = 'X-Shopify-Access-Token',
   ApiVersion = 'X-Shopify-API-Version',
   Domain = 'X-Shopify-Shop-Domain',
   Hmac = 'X-Shopify-Hmac-Sha256',
-  StorefrontAccessToken = 'X-Shopify-Storefront-Access-Token',
   Topic = 'X-Shopify-Topic',
   WebhookId = 'X-Shopify-Webhook-Id',
+  StorefrontAccessToken = 'X-Shopify-Storefront-Access-Token',
+  StorefrontSDKVariant = 'X-SDK-Variant',
+  StorefrontSDKVersion = 'X-SDK-Version',
 }
+/* eslint-enable @shopify/typescript/prefer-pascal-case-enums */
 
 export enum ClientType {
   Rest = 'rest',


### PR DESCRIPTION
### WHY are these changes introduced?

The Storefront API has been updated to allow a few headers to improve how we track requests to it, and our client should start complying with it.

### WHAT is this pull request doing?

Making the override method where we set the headers for the GraphQL client more generic, so that it takes any number of headers, and setting the new headers in the SF API client.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

Considering this a patch from the perspective of it being a fix for tracking, rather than adding new features for users of this library.

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
