### PR TITLE
Add response headers to GraphqlQueryError

### DIFF
--- a/.changeset/stupid-roses-behave.md
+++ b/.changeset/stupid-roses-behave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Add response headers to `GraphqlQueryError`. Fixes #553

--- a/docs/reference/clients/Graphql.md
+++ b/docs/reference/clients/Graphql.md
@@ -127,6 +127,7 @@ try {
   if (error instanceof GraphqlQueryError) {
     // look at error.response for details returned from API,
     // specifically, error.response.errors[0].message
+    // Also, error.headers contains the headers of the response received from Shopify
   } else {
     // handle other errors
   }

--- a/docs/temp/generated_docs_data.json
+++ b/docs/temp/generated_docs_data.json
@@ -1,0 +1,2825 @@
+[
+  {
+    "name": "buildEmbeddedAppURL",
+    "description": "Constructs the redirection URL for [getEmbeddedAppUrl](/docs/api/shopify-api-js/auth/getembeddedappurl) based on the given `host`.\n\nThis utility relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "app.get('/redirect/endpoint', (req, res) => {\n  const redirectURL = shopify.auth.buildEmbeddedAppUrl(req.query.host);\n\n  res.redirect(redirectURL);\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "buildEmbeddedAppURL"
+      }
+    },
+    "category": "auth",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "getEmbeddedAppUrl",
+    "description": "If you need to redirect a request to your embedded app URL you can use `getEmbeddedAppUrl`.\n\nUsing this method ensures that the embedded app URL is properly constructed and brings the merchant to the right place. It is more reliable than using the shop param.\n\nThis method relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "app.get('/redirect/endpoint', async (req, res) => {\n  const redirectURL = await shopify.auth.getEmbeddedAppUrl({\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  res.redirect(redirectURL);\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "getEmbeddedAppUrl"
+      }
+    },
+    "definitions": [
+      {
+        "title": "getEmbeddedAppUrl Parameters",
+        "description": "Parameters for the `getEmbeddedAppUrl` function.",
+        "type": "GetEmbeddedAppUrlParams",
+        "typeDefinitions": {
+          "GetEmbeddedAppUrlParams": {
+            "filePath": "/auth/types.ts",
+            "name": "GetEmbeddedAppUrlParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/auth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface GetEmbeddedAppUrlParams extends AdapterArgs {}"
+          },
+          "AdapterRequest": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterRequest",
+            "value": "any",
+            "description": ""
+          },
+          "AdapterResponse": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterResponse",
+            "value": "any",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "auth",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "begin",
+    "description": "Begins the OAuth process by redirecting the merchant to the Shopify Authentication screen, where they will be asked to approve the required app scopes.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "Node.js",
+            "code": "app.get('/auth', async (req, res) => {\n  // The library will automatically redirect the user\n  await shopify.auth.begin({\n    shop: shopify.utils.sanitizeShop(req.query.shop, true),\n    callbackPath: '/auth/callback',\n    isOnline: false,\n    rawRequest: req,\n    rawResponse: res,\n  });\n});\n",
+            "language": "js"
+          },
+          {
+            "title": "Cloudflare Workers",
+            "code": "async function handleFetch(request: Request): Promise<Response> {\n  const {searchParams} = new URL(request.url);\n\n  // The library will return a Response object\n  return shopify.auth.begin({\n    shop: shopify.utils.sanitizeShop(searchParams.get('shop'), true),\n    callbackPath: '/auth/callback',\n    isOnline: false,\n    rawRequest: request,\n  });\n}\n",
+            "language": "js"
+          }
+        ],
+        "title": "begin an OAuth process"
+      }
+    },
+    "definitions": [
+      {
+        "title": "begin Parameters",
+        "description": "Parameters for the `begin` function.",
+        "type": "BeginParams",
+        "typeDefinitions": {
+          "BeginParams": {
+            "filePath": "/auth/oauth/types.ts",
+            "name": "BeginParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "shop",
+                "value": "string",
+                "description": "A Shopify domain name in the form `{exampleshop}.myshopify.com`."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "callbackPath",
+                "value": "string",
+                "description": "The path to the callback endpoint, with a leading `/`. This URL must be allowed in the Partners dashboard, or using the CLI to run your app."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "`true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes)."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface BeginParams extends AdapterArgs {\n  /** A Shopify domain name in the form `{exampleshop}.myshopify.com`. */\n  shop: string;\n  /** The path to the callback endpoint, with a leading `/`. This URL must be allowed in the Partners dashboard, or using the CLI to run your app. */\n  callbackPath: string;\n  /** `true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes). */\n  isOnline: boolean;\n}"
+          },
+          "AdapterRequest": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterRequest",
+            "value": "any",
+            "description": ""
+          },
+          "AdapterResponse": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterResponse",
+            "value": "any",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "auth",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "callback",
+    "description": "Process Shopify's callback request after the user approves the app installation. Once the merchant approves the app's request for scopes, Shopify will redirect them back to your app, using the `callbackPath` parameter from `auth.begin`.\n\nYour app must then call `auth.callback` to complete the OAuth process, which will create a new Shopify `Session` and return the appropriate HTTP headers your app with which your app must respond.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "Node.js",
+            "code": "app.get('/auth/callback', async (req, res) => {\n  // The library will automatically set the appropriate HTTP headers\n  const callback = await shopify.auth.callback({\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // You can now use callback.session to make API requests\n\n  res.redirect('/my-apps-entry-page');\n});\n",
+            "language": "js"
+          },
+          {
+            "title": "Cloudflare Workers",
+            "code": "async function handleFetch(request: Request): Promise<Response> {\n  const callback = await shopify.auth.callback<Headers>({\n    rawRequest: request,\n  });\n\n  // You can now use callback.session to make API requests\n\n  // The callback returns some HTTP headers, but you can redirect to any route here\n  return new Response('', {\n    status: 302,\n    // Headers are of type [string, string][]\n    headers: [...callback.headers, ['Location', '/my-apps-entry-page']],\n  });\n}\n",
+            "language": "js"
+          }
+        ],
+        "title": "complete the OAuth process"
+      }
+    },
+    "definitions": [
+      {
+        "title": "callback Parameters",
+        "description": "Parameters for the `callback` function.",
+        "type": "CallbackParams",
+        "typeDefinitions": {
+          "CallbackParams": {
+            "filePath": "/auth/oauth/types.ts",
+            "name": "CallbackParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Deprecated as of `v6.0.1`. Session type is automatically detected from response.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface CallbackParams extends AdapterArgs {\n  /** Deprecated as of `v6.0.1`. Session type is automatically detected from response. */\n  isOnline?: boolean;\n}"
+          },
+          "AdapterRequest": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterRequest",
+            "value": "any",
+            "description": ""
+          },
+          "AdapterResponse": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterResponse",
+            "value": "any",
+            "description": ""
+          }
+        }
+      },
+      {
+        "title": "callback Return",
+        "description": "Return type of the `callback` function.",
+        "type": "CallbackResponse",
+        "typeDefinitions": {
+          "CallbackResponse": {
+            "filePath": "/auth/oauth/oauth.ts",
+            "name": "CallbackResponse",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/oauth.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "T",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/oauth/oauth.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              }
+            ],
+            "value": "export interface CallbackResponse<T = AdapterHeaders> {\n  headers: T;\n  session: Session;\n}"
+          }
+        }
+      }
+    ],
+    "category": "auth",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "nonce",
+    "description": "Generates a string of 15 characters that are cryptographically random, suitable for short-lived values in cookies to aid validation of requests/responses.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "const state = shopify.auth.nonce();\n",
+            "language": "js"
+          }
+        ],
+        "title": "nonce"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Props",
+        "description": "",
+        "type": "NonceGeneratedType",
+        "typeDefinitions": {
+          "NonceGeneratedType": {
+            "filePath": "/auth/oauth/nonce.ts",
+            "name": "NonceGeneratedType",
+            "params": [],
+            "returns": {
+              "filePath": "/auth/oauth/nonce.ts",
+              "description": "A 15 character random string",
+              "name": "string",
+              "value": "string"
+            },
+            "value": "export function nonce(): string {\n  const length = 15;\n\n  // eslint-disable-next-line no-warning-comments\n  // TODO Remove the randomBytes call when dropping Node 14 support\n  const bytes = crypto.getRandomValues\n    ? crypto.getRandomValues(new Uint8Array(length))\n    : (crypto as any).randomBytes(length);\n\n  const nonce = bytes\n    .map((byte: number) => {\n      return byte % 10;\n    })\n    .join('');\n\n  return nonce;\n}"
+          }
+        }
+      }
+    ],
+    "category": "auth",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "safeCompare",
+    "description": "Takes a pair of arguments (see below for acceptable types) and returns true if they are identical, both in term of type and content.\n\nThrows a `SafeCompareError` if the types don't match.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "const stringArray1 = ['alice', 'bob', 'charlie'];\nconst stringArray2 = ['alice', 'bob', 'charlie'];\n\nconst stringArrayResult = shopify.auth.safeCompare(stringArray1, stringArray2); // true\n\nconst array1 = ['one fish', 'two fish'];\nconst array2 = ['red fish', 'blue fish'];\nconst arrayResult = shopify.auth.safeCompare(array1, array2); // false\n\nconst arg1 = 'hello';\nconst arg2 = ['world'];\n\nconst argResult = shopify.auth.safeCompare(arg1, arg2); // throws SafeCompareError due to argument type mismatch\n",
+            "language": "js"
+          }
+        ],
+        "title": "safeCompare"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Props",
+        "description": "",
+        "type": "SafeCompareGeneratedType",
+        "typeDefinitions": {
+          "SafeCompareGeneratedType": {
+            "filePath": "/auth/oauth/safe-compare.ts",
+            "name": "SafeCompareGeneratedType",
+            "params": [
+              {
+                "name": "item1",
+                "description": "first value to compare",
+                "value": "SafeCompareParam",
+                "filePath": "/auth/oauth/safe-compare.ts"
+              },
+              {
+                "name": "item2",
+                "description": "second value to compare",
+                "value": "SafeCompareParam",
+                "filePath": "/auth/oauth/safe-compare.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/auth/oauth/safe-compare.ts",
+              "description": "whether the two input values are equal",
+              "name": "boolean",
+              "value": "boolean"
+            },
+            "value": "export function safeCompare(\n  item1: SafeCompareParam,\n  item2: SafeCompareParam,\n): boolean {\n  if (typeof item1 === typeof item2) {\n    const enc = new TextEncoder();\n    const buffA = enc.encode(JSON.stringify(item1));\n    const buffB = enc.encode(JSON.stringify(item2));\n\n    if (buffA.length === buffB.length) {\n      return timingSafeEqual(buffA, buffB);\n    }\n  } else {\n    throw new ShopifyErrors.SafeCompareError(\n      `Mismatched data types provided: ${typeof item1} and ${typeof item2}`,\n    );\n  }\n  return false;\n}"
+          },
+          "SafeCompareParam": {
+            "filePath": "/auth/oauth/safe-compare.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "SafeCompareParam",
+            "value": "string | {[key: string]: string} | string[] | number[]",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "auth",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "check",
+    "description": "Checks if a payment exists for any of the given plans, by querying the Shopify Admin API.\n\n > Note: \nDepending on the number of requests your app handles, you might want to cache a merchant's payment status, but you should periodically call this method to ensure you're blocking unpaid access.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "// This can happen at any point after the merchant goes through the OAuth process, as long as there is a session object\n// The session can be retrieved from storage using the session id returned from shopify.session.getCurrentId\nasync function billingMiddleware(req, res, next) {\n  const sessionId = shopify.session.getCurrentId({\n    isOnline: true,\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // use sessionId to retrieve session from app's session storage\n  // In this example, getSessionFromStorage() must be provided by app\n  const session = await getSessionFromStorage(sessionId);\n\n  const hasPayment = await shopify.billing.check({\n    session,\n    plans: ['My billing plan'],\n    isTest: true,\n  });\n\n  if (hasPayment) {\n    next();\n  } else {\n    // Either request payment now (if single plan) or redirect to plan selection page (if multiple plans available), e.g.\n    const confirmationUrl = await shopify.billing.request({\n      session,\n      plan: 'My billing plan',\n      isTest: true,\n    });\n\n    res.redirect(confirmationUrl);\n  }\n}\n\napp.use('/requires-payment/*', billingMiddleware);\n",
+            "language": "js"
+          }
+        ],
+        "title": "check"
+      }
+    },
+    "definitions": [
+      {
+        "title": "check Parameters",
+        "description": "Parameters for the `check` function.",
+        "type": "CheckParams",
+        "typeDefinitions": {
+          "CheckParams": {
+            "filePath": "/billing/types.ts",
+            "name": "CheckParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "The Session for the current request."
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "plans",
+                "value": "string | string[]",
+                "description": "Name of plans to search."
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isTest",
+                "value": "boolean",
+                "description": "Whether to look for test purchases only. Defaults to `true`.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface CheckParams {\n  /** The Session for the current request. */\n  session: Session;\n  /** Name of plans to search. */\n  plans: string[] | string;\n  /** Whether to look for test purchases only. Defaults to `true`. */\n  isTest?: boolean;\n}"
+          }
+        }
+      },
+      {
+        "title": "check Return",
+        "description": "`true` if there is a payment for any of the given plans, and `false` otherwise.",
+        "type": "CheckResponse",
+        "typeDefinitions": {
+          "CheckResponse": {
+            "filePath": "/billing/check.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "CheckResponse",
+            "value": "boolean",
+            "description": "true if there is a payment for any of the given plans, and false otherwise."
+          }
+        }
+      }
+    ],
+    "category": "billing",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "request",
+    "description": "Creates a new charge for the merchant, for the given plan.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "Single-plan setup - charge after OAuth completes",
+            "code": "app.get('/auth/callback', async () => {\n  const callback = await shopify.auth.callback({\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // Check if we require payment, using shopify.billing.check()\n\n  const confirmationUrl = await shopify.billing.request({\n    session: callback.session,\n    plan: 'My billing plan',\n    isTest: true,\n  });\n\n  res.redirect(confirmationUrl);\n});\n",
+            "language": "js"
+          },
+          {
+            "title": "Multi-plan setup - charge based on user selection",
+            "code": "app.post('/api/select-plan', async (req, res) => {\n  const sessionId = shopify.session.getCurrentId({\n    isOnline: true,\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // use sessionId to retrieve session from app's session storage\n  // In this example, getSessionFromStorage() must be provided by app\n  const session = await getSessionFromStorage(sessionId);\n\n  const confirmationUrl = await shopify.billing.request({\n    session,\n    // Receive the selected plan from the frontend\n    plan: req.body.selectedPlan,\n    isTest: true,\n  });\n\n  res.redirect(confirmationUrl);\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "request"
+      }
+    },
+    "definitions": [
+      {
+        "title": "request Parameters",
+        "description": "Parameters for the `request` function.",
+        "type": "RequestParams",
+        "typeDefinitions": {
+          "RequestParams": {
+            "filePath": "/billing/types.ts",
+            "name": "RequestParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "The Session for the current request."
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "plan",
+                "value": "string",
+                "description": "Name of plan to create a charge for."
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isTest",
+                "value": "boolean",
+                "description": "If `true`, Shopify will not actually charge for this purchase. Defaults to `true`.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface RequestParams {\n  /** The Session for the current request. */\n  session: Session;\n  /** Name of plan to create a charge for. */\n  plan: string;\n  /** If `true`, Shopify will not actually charge for this purchase. Defaults to `true`. */\n  isTest?: boolean;\n}"
+          }
+        }
+      },
+      {
+        "title": "request Return",
+        "description": "The URL to confirm the charge with the merchant - we don't redirect right away to make it possible for apps to run their own code after it creates the payment request.\n\nThe app must redirect the merchant to this URL so that they can confirm the charge before Shopify applies it. The merchant will be sent back to your app's main page after the process is complete.",
+        "type": "BillingRequestResponse",
+        "typeDefinitions": {
+          "BillingRequestResponse": {
+            "filePath": "/billing/request.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "BillingRequestResponse",
+            "value": "string",
+            "description": "The URL to confirm the charge with the merchant - the library will not redirect right away to make it possible for apps to run their own code after it creates the payment request.\nThe app must redirect the merchant to this URL so that they can confirm the charge before Shopify applies it. The merchant will be sent back to the app's main page after the process is complete."
+          }
+        }
+      }
+    ],
+    "category": "billing",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "shopifyApi",
+    "description": "Creates a new library object that provides all features needed for an app to interact with Shopify APIs.\n\nUse this function when you set up your app.",
+    "requires": "",
+    "type": "Entry point",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "featureFlag": "",
+      "image": "",
+      "codeblock": {
+        "tabs": [
+          {
+            "title": "JS",
+            "code": "import {shopifyApi, ApiVersion, BillingInterval} from '@shopify/shopify-api';\nimport {restResources} from '@shopify/shopify-api/rest/admin/2022-07';\n\nconst shopify = shopifyApi({\n  apiKey: 'APIKeyFromPartnersDashboard',\n  apiSecretKey: 'APISecretFromPartnersDashboard',\n  scopes: ['read_products'],\n  hostName: 'localhost:4321',\n  hostScheme: 'http',\n  apiVersion: ApiVersion.July22,\n  isEmbeddedApp: true,\n  isCustomStoreApp: false,\n  userAgentPrefix: 'Custom prefix',\n  privateAppStorefrontAccessToken: 'PrivateAccessToken',\n  customShopDomains: ['*.my-custom-domain.io'],\n  billing: {\n    'My plan': {\n      amount: 5.0,\n      currencyCode: 'USD',\n      interval: BillingInterval.OneTime,\n    },\n  },\n  logger: {\n    log: (severity, message) => {\n      myAppsLogFunction(severity, message);\n    },\n  },\n  restResources,\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "Create the Shopify API library"
+      }
+    },
+    "definitions": [
+      {
+        "title": "config",
+        "description": "Parameter passed into `shopifyApi`.",
+        "type": "ConfigParams",
+        "typeDefinitions": {
+          "ConfigParams": {
+            "filePath": "/base-types.ts",
+            "name": "ConfigParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiKey",
+                "value": "string",
+                "description": "API key for the app. You can find it in the Partners Dashboard."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiSecretKey",
+                "value": "string",
+                "description": "API secret key for the app. You can find it in the Partners Dashboard."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scopes",
+                "value": "string[] | AuthScopes",
+                "description": "[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hostName",
+                "value": "string",
+                "description": "App host name in the format `my-host-name.com`. Do not include the scheme or leading or trailing slashes."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hostScheme",
+                "value": "\"http\" | \"https\"",
+                "description": "The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiVersion",
+                "value": "ApiVersion",
+                "description": "API version your app will be querying, e.g., `ApiVersion.October22`. Defaults to `LATEST_API_VERSION`"
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isEmbeddedApp",
+                "value": "boolean",
+                "description": "Whether your app will run within the Shopify Admin. Defaults to `true`. Learn more about embedded apps with [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup)"
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isCustomStoreApp",
+                "value": "boolean",
+                "description": "Whether you are building a custom app for a store. Defaults to `false`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userAgentPrefix",
+                "value": "string",
+                "description": "Any prefix you wish to include in the User-Agent for requests made by the library. Defaults to `undefined`",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "privateAppStorefrontAccessToken",
+                "value": "string",
+                "description": "Fixed Storefront API access token for custom store apps. Defaults to `undefined`",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customShopDomains",
+                "value": "(string | RegExp)[]",
+                "description": "Use this if you need to allow values other than myshopify.com. Defaults to `undefined`",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "billing",
+                "value": "BillingConfig",
+                "description": "Billing configurations. Defaults to `undefined`. See [documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/billing.md) for full description.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "restResources",
+                "value": "T",
+                "description": "Mounts the given REST resources onto the object. Note: Must use the same version as `apiVersion`. Learn more about [using REST resources](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/rest-resources.md)",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logger",
+                "value": "{ log?: LogFunction; level?: LogSeverity; httpRequests?: boolean; timestamps?: boolean; }",
+                "description": "Tweaks the behaviour of the package's internal logging to make it easier to debug applications.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface ConfigParams<T extends ShopifyRestResources = any> {\n  /** API key for the app. You can find it in the Partners Dashboard. */\n  apiKey: string;\n  /** API secret key for the app. You can find it in the Partners Dashboard. */\n  apiSecretKey: string;\n  /** [Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app. */\n  scopes: string[] | AuthScopes;\n  /** App host name in the format `my-host-name.com`. Do not include the scheme or leading or trailing slashes. */\n  hostName: string;\n  /** The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`. */\n  hostScheme?: 'http' | 'https';\n  /** API version your app will be querying, e.g., `ApiVersion.October22`. Defaults to `LATEST_API_VERSION` */\n  apiVersion: ApiVersion;\n  /** Whether your app will run within the Shopify Admin. Defaults to `true`. Learn more about embedded apps with [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup) */\n  isEmbeddedApp: boolean;\n  /** Whether you are building a custom app for a store. Defaults to `false`. */\n  isCustomStoreApp?: boolean;\n  /** Any prefix you wish to include in the User-Agent for requests made by the library. Defaults to `undefined` */\n  userAgentPrefix?: string;\n  /** Fixed Storefront API access token for custom store apps. Defaults to `undefined` */\n  privateAppStorefrontAccessToken?: string;\n  /** Use this if you need to allow values other than myshopify.com. Defaults to `undefined` */\n  customShopDomains?: (RegExp | string)[];\n  /** Billing configurations. Defaults to `undefined`. See [documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/billing.md) for full description. */\n  billing?: BillingConfig;\n  /** Mounts the given REST resources onto the object. Note: Must use the same version as `apiVersion`. Learn more about [using REST resources](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/rest-resources.md) */\n  restResources?: T;\n  /** Tweaks the behaviour of the package's internal logging to make it easier to debug applications. */\n  logger?: {\n    /** Async callback function used for logging, which takes in a `LogSeverity` value and a formatted message. Defaults to using console calls matching the severity parameter. */\n    log?: LogFunction;\n    /** Minimum severity for which to trigger the log function. Defaults to `LogSeverity.Info`. */\n    level?: LogSeverity;\n    /** Whether or not to log ALL HTTP requests made by the package. Defaults to `false`. Note: Only takes effect if `level` is set to `LogSeverity.Debug`. */\n    httpRequests?: boolean;\n    /** Whether or not to add the current timestamp to every logged message. Defaults to `false`. */\n    timestamps?: boolean;\n  };\n}"
+          },
+          "ApiVersion": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "ApiVersion",
+            "value": "export enum ApiVersion {\n  January22 = '2022-01',\n  April22 = '2022-04',\n  July22 = '2022-07',\n  October22 = '2022-10',\n  January23 = '2023-01',\n  Unstable = 'unstable',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "January22",
+                "value": "2022-01"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "April22",
+                "value": "2022-04"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "July22",
+                "value": "2022-07"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "October22",
+                "value": "2022-10"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "January23",
+                "value": "2023-01"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Unstable",
+                "value": "unstable"
+              }
+            ]
+          },
+          "BillingConfig": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfig",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "name": "[plan: string]",
+                "value": "| BillingConfigOneTimePlan\n    | BillingConfigSubscriptionPlan\n    | BillingConfigUsagePlan"
+              }
+            ],
+            "value": "export interface BillingConfig {\n  [plan: string]:\n    | BillingConfigOneTimePlan\n    | BillingConfigSubscriptionPlan\n    | BillingConfigUsagePlan;\n}"
+          },
+          "BillingConfigOneTimePlan": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfigOneTimePlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.OneTime",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n  interval: BillingInterval.OneTime;\n}"
+          },
+          "BillingInterval": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingInterval",
+            "value": "export enum BillingInterval {\n  OneTime = 'ONE_TIME',\n  Every30Days = 'EVERY_30_DAYS',\n  Annual = 'ANNUAL',\n  Usage = 'USAGE',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "OneTime",
+                "value": "ONE_TIME"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Every30Days",
+                "value": "EVERY_30_DAYS"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Annual",
+                "value": "ANNUAL"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Usage",
+                "value": "USAGE"
+              }
+            ]
+          },
+          "BillingConfigSubscriptionPlan": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfigSubscriptionPlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "RecurringBillingIntervals",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n  interval: RecurringBillingIntervals;\n  trialDays?: number;\n  replacementBehavior?: BillingReplacementBehavior;\n}"
+          },
+          "RecurringBillingIntervals": {
+            "filePath": "/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RecurringBillingIntervals",
+            "value": "RecurringBillingIntervals",
+            "description": ""
+          },
+          "BillingReplacementBehavior": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingReplacementBehavior",
+            "value": "export enum BillingReplacementBehavior {\n  ApplyImmediately = 'APPLY_IMMEDIATELY',\n  ApplyOnNextBillingCycle = 'APPLY_ON_NEXT_BILLING_CYCLE',\n  Standard = 'STANDARD',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "ApplyImmediately",
+                "value": "APPLY_IMMEDIATELY"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "ApplyOnNextBillingCycle",
+                "value": "APPLY_ON_NEXT_BILLING_CYCLE"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Standard",
+                "value": "STANDARD"
+              }
+            ]
+          },
+          "BillingConfigUsagePlan": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfigUsagePlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Usage",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "usageTerms",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n  interval: BillingInterval.Usage;\n  usageTerms: string;\n  trialDays?: number;\n  replacementBehavior?: BillingReplacementBehavior;\n}"
+          },
+          "LogFunction": {
+            "filePath": "/base-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogFunction",
+            "value": "(severity: LogSeverity, msg: string) => Promise<void>",
+            "description": ""
+          },
+          "LogSeverity": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "LogSeverity",
+            "value": "export enum LogSeverity {\n  Error,\n  Warning,\n  Info,\n  Debug,\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "Error",
+                "value": 0
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Warning",
+                "value": 1
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Info",
+                "value": 2
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Debug",
+                "value": 3
+              }
+            ]
+          }
+        }
+      },
+      {
+        "title": "Shopify",
+        "description": "Object returned by `shopifyApi`.",
+        "type": "Shopify",
+        "typeDefinitions": {
+          "Shopify": {
+            "filePath": "/index.ts",
+            "name": "Shopify",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "config",
+                "value": "ConfigInterface",
+                "description": "The options used to set up the object, containing the validated parameters of the `shopifyApi` function."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "clients",
+                "value": "ShopifyClients",
+                "description": "Object containing clients to access Shopify APIs."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "auth",
+                "value": "ShopifyAuth",
+                "description": "Object containing functions to authenticate with Shopify APIs."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "ShopifySession",
+                "description": "Object containing functions to manage Shopify sessions."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "utils",
+                "value": "ShopifyUtils",
+                "description": "Object containing general functions to help build apps."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "webhooks",
+                "value": "ShopifyWebhooks",
+                "description": "Object containing functions to configure and handle Shopify webhooks."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "billing",
+                "value": "ShopifyBilling",
+                "description": "Object containing functions to enable apps to bill merchants."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logger",
+                "value": "ShopifyLogger",
+                "description": "Object containing functions to log messages."
+              },
+              {
+                "filePath": "/index.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rest",
+                "value": "T",
+                "description": "Object containing object-oriented representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/docs/api/admin-rest) for details."
+              }
+            ],
+            "value": "export interface Shopify<\n  T extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /** The options used to set up the object, containing the validated parameters of the `shopifyApi` function. */\n  config: ConfigInterface;\n  /** Object containing clients to access Shopify APIs. */\n  clients: ShopifyClients;\n  /** Object containing functions to authenticate with Shopify APIs. */\n  auth: ShopifyAuth;\n  /** Object containing functions to manage Shopify sessions. */\n  session: ShopifySession;\n  /** Object containing general functions to help build apps. */\n  utils: ShopifyUtils;\n  /** Object containing functions to configure and handle Shopify webhooks. */\n  webhooks: ShopifyWebhooks;\n  /** Object containing functions to enable apps to bill merchants. */\n  billing: ShopifyBilling;\n  /** Object containing functions to log messages. */\n  logger: ShopifyLogger;\n  /** Object containing object-oriented representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/docs/api/admin-rest) for details. */\n  rest: T;\n}"
+          },
+          "ConfigInterface": {
+            "filePath": "/base-types.ts",
+            "name": "ConfigInterface",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hostScheme",
+                "value": "\"http\" | \"https\"",
+                "description": "The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scopes",
+                "value": "AuthScopes",
+                "description": "[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isCustomStoreApp",
+                "value": "boolean",
+                "description": "Whether you are building a custom app for a store. Defaults to `false`."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logger",
+                "value": "{ log: LogFunction; level: LogSeverity; httpRequests: boolean; timestamps: boolean; }",
+                "description": "Tweaks the behaviour of the package's internal logging to make it easier to debug applications."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiKey",
+                "value": "string",
+                "description": "API key for the app. You can find it in the Partners Dashboard."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiSecretKey",
+                "value": "string",
+                "description": "API secret key for the app. You can find it in the Partners Dashboard."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scopes",
+                "value": "string[] | AuthScopes",
+                "description": "[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hostName",
+                "value": "string",
+                "description": "App host name in the format `my-host-name.com`. Do not include the scheme or leading or trailing slashes."
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hostScheme",
+                "value": "\"http\" | \"https\"",
+                "description": "The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiVersion",
+                "value": "ApiVersion",
+                "description": "API version your app will be querying, e.g., `ApiVersion.October22`. Defaults to `LATEST_API_VERSION`"
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isEmbeddedApp",
+                "value": "boolean",
+                "description": "Whether your app will run within the Shopify Admin. Defaults to `true`. Learn more about embedded apps with [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup)"
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isCustomStoreApp",
+                "value": "boolean",
+                "description": "Whether you are building a custom app for a store. Defaults to `false`.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "userAgentPrefix",
+                "value": "string",
+                "description": "Any prefix you wish to include in the User-Agent for requests made by the library. Defaults to `undefined`",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "privateAppStorefrontAccessToken",
+                "value": "string",
+                "description": "Fixed Storefront API access token for custom store apps. Defaults to `undefined`",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customShopDomains",
+                "value": "(string | RegExp)[]",
+                "description": "Use this if you need to allow values other than myshopify.com. Defaults to `undefined`",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "billing",
+                "value": "BillingConfig",
+                "description": "Billing configurations. Defaults to `undefined`. See [documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/billing.md) for full description.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/base-types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "logger",
+                "value": "{ log?: LogFunction; level?: LogSeverity; httpRequests?: boolean; timestamps?: boolean; }",
+                "description": "Tweaks the behaviour of the package's internal logging to make it easier to debug applications.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface ConfigInterface extends Omit<ConfigParams, 'restResources'> {\n  hostScheme: 'http' | 'https';\n  scopes: AuthScopes;\n  isCustomStoreApp: boolean;\n  logger: {\n    log: LogFunction;\n    level: LogSeverity;\n    httpRequests: boolean;\n    timestamps: boolean;\n  };\n}"
+          },
+          "LogFunction": {
+            "filePath": "/base-types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LogFunction",
+            "value": "(severity: LogSeverity, msg: string) => Promise<void>",
+            "description": ""
+          },
+          "LogSeverity": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "LogSeverity",
+            "value": "export enum LogSeverity {\n  Error,\n  Warning,\n  Info,\n  Debug,\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "Error",
+                "value": 0
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Warning",
+                "value": 1
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Info",
+                "value": 2
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Debug",
+                "value": 3
+              }
+            ]
+          },
+          "ApiVersion": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "ApiVersion",
+            "value": "export enum ApiVersion {\n  January22 = '2022-01',\n  April22 = '2022-04',\n  July22 = '2022-07',\n  October22 = '2022-10',\n  January23 = '2023-01',\n  Unstable = 'unstable',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "January22",
+                "value": "2022-01"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "April22",
+                "value": "2022-04"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "July22",
+                "value": "2022-07"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "October22",
+                "value": "2022-10"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "January23",
+                "value": "2023-01"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Unstable",
+                "value": "unstable"
+              }
+            ]
+          },
+          "BillingConfig": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfig",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "name": "[plan: string]",
+                "value": "| BillingConfigOneTimePlan\n    | BillingConfigSubscriptionPlan\n    | BillingConfigUsagePlan"
+              }
+            ],
+            "value": "export interface BillingConfig {\n  [plan: string]:\n    | BillingConfigOneTimePlan\n    | BillingConfigSubscriptionPlan\n    | BillingConfigUsagePlan;\n}"
+          },
+          "BillingConfigOneTimePlan": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfigOneTimePlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.OneTime",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n  interval: BillingInterval.OneTime;\n}"
+          },
+          "BillingInterval": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingInterval",
+            "value": "export enum BillingInterval {\n  OneTime = 'ONE_TIME',\n  Every30Days = 'EVERY_30_DAYS',\n  Annual = 'ANNUAL',\n  Usage = 'USAGE',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "OneTime",
+                "value": "ONE_TIME"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Every30Days",
+                "value": "EVERY_30_DAYS"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Annual",
+                "value": "ANNUAL"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Usage",
+                "value": "USAGE"
+              }
+            ]
+          },
+          "BillingConfigSubscriptionPlan": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfigSubscriptionPlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "RecurringBillingIntervals",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n  interval: RecurringBillingIntervals;\n  trialDays?: number;\n  replacementBehavior?: BillingReplacementBehavior;\n}"
+          },
+          "RecurringBillingIntervals": {
+            "filePath": "/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RecurringBillingIntervals",
+            "value": "RecurringBillingIntervals",
+            "description": ""
+          },
+          "BillingReplacementBehavior": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingReplacementBehavior",
+            "value": "export enum BillingReplacementBehavior {\n  ApplyImmediately = 'APPLY_IMMEDIATELY',\n  ApplyOnNextBillingCycle = 'APPLY_ON_NEXT_BILLING_CYCLE',\n  Standard = 'STANDARD',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "ApplyImmediately",
+                "value": "APPLY_IMMEDIATELY"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "ApplyOnNextBillingCycle",
+                "value": "APPLY_ON_NEXT_BILLING_CYCLE"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Standard",
+                "value": "STANDARD"
+              }
+            ]
+          },
+          "BillingConfigUsagePlan": {
+            "filePath": "/billing/types.ts",
+            "name": "BillingConfigUsagePlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Usage",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "usageTerms",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n  interval: BillingInterval.Usage;\n  usageTerms: string;\n  trialDays?: number;\n  replacementBehavior?: BillingReplacementBehavior;\n}"
+          },
+          "ShopifyClients": {
+            "filePath": "/clients/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyClients",
+            "value": "ReturnType<typeof clientClasses>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/clients/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "Rest",
+                "value": "typeof RestClient",
+                "description": ""
+              },
+              {
+                "filePath": "/clients/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "Graphql",
+                "value": "typeof GraphqlClient",
+                "description": ""
+              },
+              {
+                "filePath": "/clients/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "Storefront",
+                "value": "typeof StorefrontClient",
+                "description": ""
+              },
+              {
+                "filePath": "/clients/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "graphqlProxy",
+                "value": "({ session, rawBody, }: GraphqlProxyParams) => Promise<RequestReturn<unknown>>",
+                "description": ""
+              }
+            ]
+          },
+          "Body": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+            "name": "Body",
+            "description": "",
+            "members": [
+              {
+                "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+                "name": "[key: string]",
+                "value": "any"
+              }
+            ],
+            "value": "export interface Body {\n  [key: string]: any;\n}"
+          },
+          "GraphqlProxyParams": {
+            "filePath": "/clients/graphql/types.ts",
+            "name": "GraphqlProxyParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/clients/graphql/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "/clients/graphql/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawBody",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface GraphqlProxyParams {\n  session: Session;\n  rawBody: string;\n}"
+          },
+          "RequestReturn": {
+            "filePath": "/clients/http_client/types.ts",
+            "name": "RequestReturn",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/clients/http_client/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "body",
+                "value": "T",
+                "description": ""
+              },
+              {
+                "filePath": "/clients/http_client/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "Headers",
+                "description": ""
+              }
+            ],
+            "value": "export interface RequestReturn<T = unknown> {\n  body: T;\n  headers: Headers;\n}"
+          },
+          "Headers": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "name": "Headers",
+            "description": "",
+            "members": [
+              {
+                "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+                "name": "[key: string]",
+                "value": "string | string[]"
+              }
+            ],
+            "value": "export interface Headers {\n  [key: string]: string | string[];\n}"
+          },
+          "ShopifyAuth": {
+            "filePath": "/auth/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyAuth",
+            "value": "ReturnType<typeof shopifyAuth>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "begin",
+                "value": "({ shop, callbackPath, isOnline, ...adapterArgs }: BeginParams) => Promise<any>",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "callback",
+                "value": "<T = any>({ isOnline: isOnlineParam, ...adapterArgs }: CallbackParams) => Promise<CallbackResponse<T>>",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/index.ts",
+                "syntaxKind": "ShorthandPropertyAssignment",
+                "name": "nonce",
+                "value": "() => string",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/index.ts",
+                "syntaxKind": "ShorthandPropertyAssignment",
+                "name": "safeCompare",
+                "value": "(item1: SafeCompareParam, item2: SafeCompareParam) => boolean",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "getEmbeddedAppUrl",
+                "value": "({ ...adapterArgs }: GetEmbeddedAppUrlParams) => Promise<string>",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "buildEmbeddedAppUrl",
+                "value": "(host: string) => string",
+                "description": ""
+              }
+            ]
+          },
+          "BeginParams": {
+            "filePath": "/auth/oauth/types.ts",
+            "name": "BeginParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "shop",
+                "value": "string",
+                "description": "A Shopify domain name in the form `{exampleshop}.myshopify.com`."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "callbackPath",
+                "value": "string",
+                "description": "The path to the callback endpoint, with a leading `/`. This URL must be allowed in the Partners dashboard, or using the CLI to run your app."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "`true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes)."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface BeginParams extends AdapterArgs {\n  /** A Shopify domain name in the form `{exampleshop}.myshopify.com`. */\n  shop: string;\n  /** The path to the callback endpoint, with a leading `/`. This URL must be allowed in the Partners dashboard, or using the CLI to run your app. */\n  callbackPath: string;\n  /** `true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes). */\n  isOnline: boolean;\n}"
+          },
+          "AdapterRequest": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterRequest",
+            "value": "any",
+            "description": ""
+          },
+          "AdapterResponse": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterResponse",
+            "value": "any",
+            "description": ""
+          },
+          "CallbackParams": {
+            "filePath": "/auth/oauth/types.ts",
+            "name": "CallbackParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Deprecated as of `v6.0.1`. Session type is automatically detected from response.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface CallbackParams extends AdapterArgs {\n  /** Deprecated as of `v6.0.1`. Session type is automatically detected from response. */\n  isOnline?: boolean;\n}"
+          },
+          "CallbackResponse": {
+            "filePath": "/auth/oauth/oauth.ts",
+            "name": "CallbackResponse",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/oauth.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "T",
+                "description": ""
+              },
+              {
+                "filePath": "/auth/oauth/oauth.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              }
+            ],
+            "value": "export interface CallbackResponse<T = AdapterHeaders> {\n  headers: T;\n  session: Session;\n}"
+          },
+          "SafeCompareParam": {
+            "filePath": "/auth/oauth/safe-compare.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "SafeCompareParam",
+            "value": "string | {[key: string]: string} | string[] | number[]",
+            "description": ""
+          },
+          "GetEmbeddedAppUrlParams": {
+            "filePath": "/auth/types.ts",
+            "name": "GetEmbeddedAppUrlParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/auth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface GetEmbeddedAppUrlParams extends AdapterArgs {}"
+          },
+          "ShopifySession": {
+            "filePath": "/session/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifySession",
+            "value": "ReturnType<typeof shopifySession>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/session/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "customAppSession",
+                "value": "(shop: string) => Session",
+                "description": ""
+              },
+              {
+                "filePath": "/session/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "getCurrentId",
+                "value": "({ isOnline, ...adapterArgs }: GetCurrentSessionIdParams) => Promise<string>",
+                "description": ""
+              },
+              {
+                "filePath": "/session/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "getOfflineId",
+                "value": "(shop: string) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/session/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "decodeSessionToken",
+                "value": "(token: string) => Promise<JwtPayload>",
+                "description": ""
+              }
+            ]
+          },
+          "GetCurrentSessionIdParams": {
+            "filePath": "/session/types.ts",
+            "name": "GetCurrentSessionIdParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether to look for an offline or online session, depending on how the [`auth.begin`](/docs/api/shopify-api-js/auth/begin) method was called."
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface GetCurrentSessionIdParams extends AdapterArgs {\n  /** Whether to look for an offline or online session, depending on how the [`auth.begin`](/docs/api/shopify-api-js/auth/begin) method was called. */\n  isOnline: boolean;\n}"
+          },
+          "JwtPayload": {
+            "filePath": "/session/types.ts",
+            "name": "JwtPayload",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "iss",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "dest",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "aud",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sub",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "exp",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "nbf",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "iat",
+                "value": "number",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "jti",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sid",
+                "value": "string",
+                "description": ""
+              }
+            ],
+            "value": "export interface JwtPayload {\n  iss: string;\n  dest: string;\n  aud: string;\n  sub: string;\n  exp: number;\n  nbf: number;\n  iat: number;\n  jti: string;\n  sid: string;\n}"
+          },
+          "ShopifyUtils": {
+            "filePath": "/utils/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyUtils",
+            "value": "ReturnType<typeof shopifyUtils>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/utils/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "sanitizeShop",
+                "value": "(shop: string, throwOnInvalid?: boolean) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/utils/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "sanitizeHost",
+                "value": "(host: string, throwOnInvalid?: boolean) => string",
+                "description": ""
+              },
+              {
+                "filePath": "/utils/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "validateHmac",
+                "value": "(query: AuthQuery) => Promise<boolean>",
+                "description": ""
+              },
+              {
+                "filePath": "/utils/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "versionCompatible",
+                "value": "(referenceVersion: ApiVersion, currentVersion?: ApiVersion) => boolean",
+                "description": ""
+              }
+            ]
+          },
+          "AuthQuery": {
+            "filePath": "/auth/oauth/types.ts",
+            "name": "AuthQuery",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "name": "[key: string]",
+                "value": "string | undefined"
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hmac",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AuthQuery {\n  [key: string]: string | undefined;\n  hmac?: string;\n}"
+          },
+          "ShopifyWebhooks": {
+            "filePath": "/webhooks/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyWebhooks",
+            "value": "ReturnType<typeof shopifyWebhooks>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "addHandlers",
+                "value": "(handlersToAdd: AddHandlersParams) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "getTopicsAdded",
+                "value": "() => string[]",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "getHandlers",
+                "value": "(topic: string) => WebhookHandler[]",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "register",
+                "value": "({ session, }: RegisterParams) => Promise<RegisterReturn>",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "process",
+                "value": "({ rawBody, ...adapterArgs }: WebhookProcessParams) => Promise<any>",
+                "description": ""
+              }
+            ]
+          },
+          "AddHandlersParams": {
+            "filePath": "/webhooks/types.ts",
+            "name": "AddHandlersParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "name": "[topic: string]",
+                "value": "WebhookHandler | WebhookHandler[]"
+              }
+            ],
+            "value": "export interface AddHandlersParams {\n  [topic: string]: WebhookHandler | WebhookHandler[];\n}"
+          },
+          "WebhookHandler": {
+            "filePath": "/webhooks/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "WebhookHandler",
+            "value": "HttpWebhookHandler | EventBridgeWebhookHandler | PubSubWebhookHandler",
+            "description": ""
+          },
+          "HttpWebhookHandler": {
+            "filePath": "/webhooks/types.ts",
+            "name": "HttpWebhookHandler",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "deliveryMethod",
+                "value": "DeliveryMethod.Http",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "privateMetafieldNamespaces",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "callbackUrl",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "callback",
+                "value": "WebhookHandlerFunction",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "includeFields",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "metafieldNamespaces",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface HttpWebhookHandler extends BaseWebhookHandler {\n  deliveryMethod: DeliveryMethod.Http;\n  privateMetafieldNamespaces?: string[];\n  callbackUrl: string;\n  callback: WebhookHandlerFunction;\n}"
+          },
+          "DeliveryMethod": {
+            "filePath": "/webhooks/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "DeliveryMethod",
+            "value": "export enum DeliveryMethod {\n  Http = 'http',\n  EventBridge = 'eventbridge',\n  PubSub = 'pubsub',\n}",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "name": "Http",
+                "value": "http"
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "name": "EventBridge",
+                "value": "eventbridge"
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "name": "PubSub",
+                "value": "pubsub"
+              }
+            ]
+          },
+          "WebhookHandlerFunction": {
+            "filePath": "/webhooks/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "WebhookHandlerFunction",
+            "value": "(\n  topic: string,\n  shop_domain: string,\n  body: string,\n  webhookId: string,\n  apiVersion?: string,\n) => Promise<void>",
+            "description": ""
+          },
+          "EventBridgeWebhookHandler": {
+            "filePath": "/webhooks/types.ts",
+            "name": "EventBridgeWebhookHandler",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "deliveryMethod",
+                "value": "DeliveryMethod.EventBridge",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "arn",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "includeFields",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "metafieldNamespaces",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface EventBridgeWebhookHandler extends BaseWebhookHandler {\n  deliveryMethod: DeliveryMethod.EventBridge;\n  arn: string;\n}"
+          },
+          "PubSubWebhookHandler": {
+            "filePath": "/webhooks/types.ts",
+            "name": "PubSubWebhookHandler",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "deliveryMethod",
+                "value": "DeliveryMethod.PubSub",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "pubSubProject",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "pubSubTopic",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "includeFields",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "metafieldNamespaces",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface PubSubWebhookHandler extends BaseWebhookHandler {\n  deliveryMethod: DeliveryMethod.PubSub;\n  pubSubProject: string;\n  pubSubTopic: string;\n}"
+          },
+          "RegisterParams": {
+            "filePath": "/webhooks/types.ts",
+            "name": "RegisterParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              }
+            ],
+            "value": "export interface RegisterParams {\n  session: Session;\n}"
+          },
+          "RegisterReturn": {
+            "filePath": "/webhooks/types.ts",
+            "name": "RegisterReturn",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "name": "[topic: string]",
+                "value": "RegisterResult[]"
+              }
+            ],
+            "value": "export interface RegisterReturn {\n  [topic: string]: RegisterResult[];\n}"
+          },
+          "RegisterResult": {
+            "filePath": "/webhooks/types.ts",
+            "name": "RegisterResult",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "success",
+                "value": "boolean",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "deliveryMethod",
+                "value": "DeliveryMethod",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "result",
+                "value": "unknown",
+                "description": ""
+              }
+            ],
+            "value": "export interface RegisterResult {\n  success: boolean;\n  deliveryMethod: DeliveryMethod;\n  result: unknown;\n}"
+          },
+          "WebhookProcessParams": {
+            "filePath": "/webhooks/types.ts",
+            "name": "WebhookProcessParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawBody",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface WebhookProcessParams extends AdapterArgs {\n  rawBody: string;\n}"
+          },
+          "ShopifyBilling": {
+            "filePath": "/billing/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyBilling",
+            "value": "ReturnType<typeof shopifyBilling>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "check",
+                "value": "({ session, plans, isTest, }: CheckParams) => Promise<boolean>",
+                "description": ""
+              },
+              {
+                "filePath": "/billing/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "request",
+                "value": "({ session, plan, isTest, }: RequestParams) => Promise<string>",
+                "description": ""
+              }
+            ]
+          },
+          "CheckParams": {
+            "filePath": "/billing/types.ts",
+            "name": "CheckParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "The Session for the current request."
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "plans",
+                "value": "string | string[]",
+                "description": "Name of plans to search."
+              },
+              {
+                "filePath": "/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isTest",
+                "value": "boolean",
+                "description": "Whether to look for test purchases only. Defaults to `true`.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface CheckParams {\n  /** The Session for the current request. */\n  session: Session;\n  /** Name of plans to search. */\n  plans: string[] | string;\n  /** Whether to look for test purchases only. Defaults to `true`. */\n  isTest?: boolean;\n}"
+          },
+          "ShopifyLogger": {
+            "filePath": "/logger/index.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyLogger",
+            "value": "ReturnType<typeof logger>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/logger/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "log",
+                "value": "LoggerFunction",
+                "description": ""
+              },
+              {
+                "filePath": "/logger/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "debug",
+                "value": "(message: string, context?: LogContext) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "/logger/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "info",
+                "value": "(message: string, context?: LogContext) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "/logger/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "warning",
+                "value": "(message: string, context?: LogContext) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "/logger/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "error",
+                "value": "(message: string, context?: LogContext) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "/logger/index.ts",
+                "syntaxKind": "PropertyAssignment",
+                "name": "deprecated",
+                "value": "(version: string, message: string) => Promise<void>",
+                "description": ""
+              }
+            ]
+          },
+          "LoggerFunction": {
+            "filePath": "/logger/log.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "LoggerFunction",
+            "value": "(\n  severity: LogSeverity,\n  message: string,\n  context?: {[key: string]: any},\n) => Promise<void>",
+            "description": ""
+          },
+          "LogContext": {
+            "filePath": "/logger/types.ts",
+            "name": "LogContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/logger/types.ts",
+                "name": "[key: string]",
+                "value": "any"
+              }
+            ],
+            "value": "export interface LogContext {\n  [key: string]: any;\n}"
+          }
+        }
+      }
+    ],
+    "category": "Entry point",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "getCurrentId",
+    "description": "Extracts the Shopify session id from the given request.\n\nFor embedded apps, `getCurrentId` will only be able to find a session id if you use `authenticatedFetch` from the `@shopify/app-bridge-utils` client-side package.\n\nThis function behaves like a [normal `fetch` call](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), but ensures the appropriate headers are set.\n\nLearn more about [making authenticated requests](https://shopify.dev/docs/apps/auth/oauth/session-tokens/getting-started#step-2-authenticate-your-requests) using App Bridge.\n\n> Note:\nThis method will rely on cookies for non-embedded apps, and the `Authorization` HTTP header for embedded apps using [App Bridge session tokens](https://shopify.dev/docs/apps/auth/oauth/session-tokens), making all apps safe to use in modern browsers that block 3rd party cookies.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "app.get('/fetch-some-data', async (req, res) => {\n  const sessionId = await shopify.session.getCurrentId({\n    isOnline: true,\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // use sessionId to retrieve session from app's session storage\n  // getSessionFromStorage() must be provided by application\n  const session = await getSessionFromStorage(sessionId);\n\n  // Build a client and make requests with session.accessToken\n  // See the REST, GraphQL, or Storefront API documentation for more information\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "getCurrentId"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Parameters",
+        "description": "",
+        "type": "GetCurrentSessionIdParams",
+        "typeDefinitions": {
+          "GetCurrentSessionIdParams": {
+            "filePath": "/session/types.ts",
+            "name": "GetCurrentSessionIdParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether to look for an offline or online session, depending on how the [`auth.begin`](/docs/api/shopify-api-js/auth/begin) method was called."
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The HTTP Request object used by your runtime."
+              },
+              {
+                "filePath": "/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface GetCurrentSessionIdParams extends AdapterArgs {\n  /** Whether to look for an offline or online session, depending on how the [`auth.begin`](/docs/api/shopify-api-js/auth/begin) method was called. */\n  isOnline: boolean;\n}"
+          },
+          "AdapterRequest": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterRequest",
+            "value": "any",
+            "description": ""
+          },
+          "AdapterResponse": {
+            "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdapterResponse",
+            "value": "any",
+            "description": ""
+          }
+        }
+      },
+      {
+        "title": "Returns",
+        "description": "The session id for the request, or `undefined` if none was found.",
+        "type": "GetCurrentIdReturns",
+        "typeDefinitions": {
+          "GetCurrentIdReturns": {
+            "filePath": "/session/session-utils.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "GetCurrentIdReturns",
+            "value": "string | undefined",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "session",
+    "related": []
+  },
+  {
+    "name": "getOfflineId",
+    "description": "Builds a session id that can be used to load an offline session, if there was a [`auth.begin`](/docs/api/shopify-api-js/auth/begin) call to create one.\n\n> Caution:\nThis method **_does not_** perform any validation on the `shop` parameter because it is meant for background tasks. You should **_never_** read the shop from user inputs or URLs.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "app.get('/fetch-some-data', async (req, res) => {\n  const sessionId = await shopify.session.getCurrentId({\n    isOnline: true,\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // use sessionId to retrieve session from app's session storage\n  // getSessionFromStorage() must be provided by application\n  const session = await getSessionFromStorage(sessionId);\n\n  // Build a client and make requests with session.accessToken\n  // See the REST, GraphQL, or Storefront API documentation for more information\n});\n",
+            "language": "js"
+          }
+        ],
+        "title": "getOfflineId"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Props",
+        "description": "",
+        "type": "DocumentGetOfflineIdGeneratedType",
+        "typeDefinitions": {
+          "DocumentGetOfflineIdGeneratedType": {
+            "filePath": "/session/session-utils.ts",
+            "name": "DocumentGetOfflineIdGeneratedType",
+            "params": [
+              {
+                "name": "shop",
+                "description": "The shop domain to use to build the session id.",
+                "value": "string",
+                "filePath": "/session/session-utils.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/session/session-utils.ts",
+              "description": "The session id.",
+              "name": "string",
+              "value": "string"
+            },
+            "value": "function documentGetOfflineId(shop: string): string {\n  return shop;\n}"
+          }
+        }
+      }
+    ],
+    "category": "session",
+    "related": []
+  },
+  {
+    "name": "validateHmac",
+    "description": "Shopify requests include an `hmac` query argument. This method validates those requests to ensure that the `hmac` value was signed by Shopify and not spoofed.",
+    "type": "async",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "const isValid = await shopify.utils.validateHmac(req.query);\n",
+            "language": "js"
+          }
+        ],
+        "title": "validateHmac"
+      }
+    },
+    "definitions": [
+      {
+        "title": "validateHmac Parameters",
+        "description": "Parameters for the `validateHmac` function.",
+        "type": "AuthQuery",
+        "typeDefinitions": {
+          "AuthQuery": {
+            "filePath": "/auth/oauth/types.ts",
+            "name": "AuthQuery",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "name": "[key: string]",
+                "value": "string | undefined"
+              },
+              {
+                "filePath": "/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "hmac",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface AuthQuery {\n  [key: string]: string | undefined;\n  hmac?: string;\n}"
+          }
+        }
+      },
+      {
+        "title": "validateHmac Return",
+        "description": "`true` if the `hmac` value in the query is valid, and `false` otherwise.",
+        "type": "ValidateHmacResponse",
+        "typeDefinitions": {
+          "ValidateHmacResponse": {
+            "filePath": "/utils/hmac-validator.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ValidateHmacResponse",
+            "value": "boolean",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "utils",
+    "thumbnail": "",
+    "related": []
+  },
+  {
+    "name": "sanitizeHost",
+    "description": "This method makes user inputs safer by ensuring that the `host` query arguments from Shopify requests is valid.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "const host = shopify.utils.sanitizeHost(req.query.host, true);\n",
+            "language": "js"
+          }
+        ],
+        "title": "sanitizeHost"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Parameters",
+        "description": "",
+        "type": "SanitizeHostParams",
+        "typeDefinitions": {
+          "SanitizeHostParams": {
+            "filePath": "/utils/shop-validator.ts",
+            "name": "SanitizeHostParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/utils/shop-validator.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "host",
+                "value": "string",
+                "description": "The incoming host value to sanitize."
+              },
+              {
+                "filePath": "/utils/shop-validator.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "throwOnInvalid",
+                "value": "boolean",
+                "description": "Whether to throw an error if the host is invalid. Defaults to `false`.",
+                "isOptional": true
+              }
+            ],
+            "value": "interface SanitizeHostParams {\n  /** The incoming host value to sanitize. */\n  host: string;\n  /** Whether to throw an error if the host is invalid. Defaults to `false`. */\n  throwOnInvalid?: boolean;\n}"
+          }
+        }
+      },
+      {
+        "title": "Returns",
+        "description": "The `host` value if it is properly formatted, otherwise `null`.",
+        "type": "SanitizeHostReturns",
+        "typeDefinitions": {
+          "SanitizeHostReturns": {
+            "filePath": "/utils/shop-validator.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "SanitizeHostReturns",
+            "value": "string | null",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "utils",
+    "related": []
+  },
+  {
+    "name": "sanitizeShop",
+    "description": "This method makes user inputs safer by ensuring that a given shop value is a properly formatted Shopify shop domain.\n\n > Note:\nIf you're using custom shop domains for testing, you can use the `customShopDomains` setting to add allowed domains.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "const shop = shopify.utils.sanitizeShop(req.query.shop, true);\n",
+            "language": "js"
+          }
+        ],
+        "title": "sanitizeShop"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Parameters",
+        "description": "",
+        "type": "SanitizeShopParams",
+        "typeDefinitions": {
+          "SanitizeShopParams": {
+            "filePath": "/utils/shop-validator.ts",
+            "name": "SanitizeShopParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/utils/shop-validator.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "shop",
+                "value": "string",
+                "description": "The shop to sanitize."
+              },
+              {
+                "filePath": "/utils/shop-validator.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "throwOnInvalid",
+                "value": "boolean",
+                "description": "Whether to throw an error if the shop is invalid. Defaults to `false`.",
+                "isOptional": true
+              }
+            ],
+            "value": "interface SanitizeShopParams {\n  /** The shop to sanitize. */\n  shop: string;\n  /** Whether to throw an error if the shop is invalid. Defaults to `false`. */\n  throwOnInvalid?: boolean;\n}"
+          }
+        }
+      },
+      {
+        "title": "Returns",
+        "description": "The `shop` value if it is a properly formatted Shopify shop domain, otherwise `null`.",
+        "type": "SanitizeShopReturns",
+        "typeDefinitions": {
+          "SanitizeShopReturns": {
+            "filePath": "/utils/shop-validator.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "SanitizeShopReturns",
+            "value": "string | null",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "utils",
+    "related": []
+  },
+  {
+    "name": "versionCompatible",
+    "description": "This method determines if the given version is compatible (equal to or newer) with the configured `apiVersion` for the `shopifyApi` object. Its main use is when you want to tweak behaviour depending on your current API version, though apps won't typically need this kind of check.",
+    "type": "",
+    "isVisualComponent": false,
+    "defaultExample": {
+      "codeblock": {
+        "tabs": [
+          {
+            "code": "const shopify = shopifyApi({\n  apiVersion: ApiVersion.July22,\n});\n\nif (shopify.utils.versionCompatible(ApiVersion.January22)) {\n  // true in this example, as ApiVersion.July22 is newer than ApiVersion.January22\n}\n",
+            "language": "js"
+          }
+        ],
+        "title": "versionCompatibile"
+      }
+    },
+    "definitions": [
+      {
+        "title": "Parameters",
+        "description": "",
+        "type": "VersionCompatibileParams",
+        "typeDefinitions": {
+          "VersionCompatibileParams": {
+            "filePath": "/utils/version-compatible.ts",
+            "name": "VersionCompatibileParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/utils/version-compatible.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "referenceVersion",
+                "value": "ApiVersion",
+                "description": "The API version to check against."
+              }
+            ],
+            "value": "interface VersionCompatibileParams {\n  /** The API version to check against. */\n  referenceVersion: ApiVersion;\n}"
+          },
+          "ApiVersion": {
+            "filePath": "/types.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "ApiVersion",
+            "value": "export enum ApiVersion {\n  January22 = '2022-01',\n  April22 = '2022-04',\n  July22 = '2022-07',\n  October22 = '2022-10',\n  January23 = '2023-01',\n  Unstable = 'unstable',\n}",
+            "members": [
+              {
+                "filePath": "/types.ts",
+                "name": "January22",
+                "value": "2022-01"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "April22",
+                "value": "2022-04"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "July22",
+                "value": "2022-07"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "October22",
+                "value": "2022-10"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "January23",
+                "value": "2023-01"
+              },
+              {
+                "filePath": "/types.ts",
+                "name": "Unstable",
+                "value": "unstable"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "title": "Returns",
+        "description": "`true` if the given version is compatible with the configured `apiVersion`.",
+        "type": "VersionCompatibleReturns",
+        "typeDefinitions": {
+          "VersionCompatibleReturns": {
+            "filePath": "/utils/version-compatible.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "VersionCompatibleReturns",
+            "value": "boolean",
+            "description": ""
+          }
+        }
+      }
+    ],
+    "category": "utils",
+    "related": []
+  }
+]

--- a/docs/temp/typeAST.json
+++ b/docs/temp/typeAST.json
@@ -1,0 +1,8019 @@
+{
+  "IdSet": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+      "name": "IdSet",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "name": "[id: string]",
+          "value": "string | number | null"
+        }
+      ],
+      "value": "export interface IdSet {\n  [id: string]: string | number | null;\n}"
+    }
+  },
+  "ParamSet": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+      "name": "ParamSet",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "name": "[key: string]",
+          "value": "any"
+        }
+      ],
+      "value": "export interface ParamSet {\n  [key: string]: any;\n}"
+    }
+  },
+  "Body": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+      "name": "Body",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "name": "[key: string]",
+          "value": "any"
+        }
+      ],
+      "value": "export interface Body {\n  [key: string]: any;\n}"
+    }
+  },
+  "ResourcePath": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+      "name": "ResourcePath",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "http_method",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "operation",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "ids",
+          "value": "string[]",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface ResourcePath {\n  http_method: string;\n  operation: string;\n  ids: string[];\n  path: string;\n}"
+    }
+  },
+  "ShopifyRestResources": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+      "name": "ShopifyRestResources",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/types.ts",
+          "name": "[resource: string]",
+          "value": "any"
+        }
+      ],
+      "value": "export interface ShopifyRestResources {\n  [resource: string]: any;\n}"
+    }
+  },
+  "Headers": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "name": "Headers",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "name": "[key: string]",
+          "value": "string | string[]"
+        }
+      ],
+      "value": "export interface Headers {\n  [key: string]: string | string[];\n}"
+    }
+  },
+  "NormalizedRequest": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "name": "NormalizedRequest",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "method",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "url",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "Headers",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface NormalizedRequest {\n  method: string;\n  url: string;\n  headers: Headers;\n  body?: string;\n}"
+    }
+  },
+  "NormalizedResponse": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "name": "NormalizedResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "statusCode",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "statusText",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "Headers",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface NormalizedResponse {\n  statusCode: number;\n  statusText: string;\n  headers?: Headers;\n  body?: string;\n}"
+    }
+  },
+  "AdapterRequest": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AdapterRequest",
+      "value": "any",
+      "description": ""
+    }
+  },
+  "AdapterResponse": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AdapterResponse",
+      "value": "any",
+      "description": ""
+    }
+  },
+  "AdapterHeaders": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AdapterHeaders",
+      "value": "any",
+      "description": ""
+    }
+  },
+  "AdapterArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "name": "AdapterArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "AdapterRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AdapterArgs {\n  /** The HTTP Request object used by your runtime. */\n  rawRequest: AdapterRequest;\n  /** The HTTP Response object used by your runtime. Required for Node.js. */\n  rawResponse?: AdapterResponse;\n}"
+    }
+  },
+  "AbstractFetchFunc": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AbstractFetchFunc",
+      "value": "(\n  req: NormalizedRequest,\n) => Promise<NormalizedResponse>",
+      "description": ""
+    }
+  },
+  "AbstractConvertRequestFunc": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AbstractConvertRequestFunc",
+      "value": "(\n  adapterArgs: AdapterArgs,\n) => Promise<NormalizedRequest>",
+      "description": ""
+    }
+  },
+  "AbstractConvertIncomingResponseFunc": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AbstractConvertIncomingResponseFunc",
+      "value": "(\n  adapterArgs: AdapterArgs,\n) => Promise<NormalizedResponse>",
+      "description": ""
+    }
+  },
+  "AbstractConvertResponseFunc": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AbstractConvertResponseFunc",
+      "value": "(\n  response: NormalizedResponse,\n  adapterArgs: AdapterArgs,\n) => Promise<AdapterResponse>",
+      "description": ""
+    }
+  },
+  "AbstractConvertHeadersFunc": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AbstractConvertHeadersFunc",
+      "value": "(\n  headers: Headers,\n  adapterArgs: AdapterArgs,\n) => Promise<AdapterHeaders>",
+      "description": ""
+    }
+  },
+  "HttpResponseData": {
+    "/error.ts": {
+      "filePath": "/error.ts",
+      "name": "HttpResponseData",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "statusText",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface HttpResponseData {\n  code: number;\n  statusText: string;\n  body?: {[key: string]: unknown};\n  headers?: {[key: string]: unknown};\n}"
+    }
+  },
+  "HttpResponseErrorParams": {
+    "/error.ts": {
+      "filePath": "/error.ts",
+      "name": "HttpResponseErrorParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "statusText",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface HttpResponseErrorParams extends HttpResponseData {\n  message: string;\n}"
+    }
+  },
+  "HttpThrottlingErrorData": {
+    "/error.ts": {
+      "filePath": "/error.ts",
+      "name": "HttpThrottlingErrorData",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "retryAfter",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "statusText",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface HttpThrottlingErrorData extends HttpResponseData {\n  retryAfter?: number;\n}"
+    }
+  },
+  "HttpThrottlingErrorParams": {
+    "/error.ts": {
+      "filePath": "/error.ts",
+      "name": "HttpThrottlingErrorParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "retryAfter",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "code",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "statusText",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface HttpThrottlingErrorParams extends HttpThrottlingErrorData {\n  message: string;\n}"
+    }
+  },
+  "InvalidWebhookParams": {
+    "/error.ts": {
+      "filePath": "/error.ts",
+      "name": "InvalidWebhookParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/error.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "response",
+          "value": "AdapterResponse",
+          "description": ""
+        }
+      ],
+      "value": "interface InvalidWebhookParams {\n  message: string;\n  response: AdapterResponse;\n}"
+    }
+  },
+  "SESSION_COOKIE_NAMEGeneratedType": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "SESSION_COOKIE_NAMEGeneratedType",
+      "value": "SESSION_COOKIE_NAME = 'shopify_app_session'"
+    }
+  },
+  "STATE_COOKIE_NAMEGeneratedType": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "STATE_COOKIE_NAMEGeneratedType",
+      "value": "STATE_COOKIE_NAME = 'shopify_app_state'"
+    }
+  },
+  "AuthQuery": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "AuthQuery",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "name": "[key: string]",
+          "value": "string | undefined"
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hmac",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AuthQuery {\n  [key: string]: string | undefined;\n  hmac?: string;\n}"
+    }
+  },
+  "BeginParams": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "BeginParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "string",
+          "description": "A Shopify domain name in the form `{exampleshop}.myshopify.com`."
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "callbackPath",
+          "value": "string",
+          "description": "The path to the callback endpoint, with a leading `/`. This URL must be allowed in the Partners dashboard, or using the CLI to run your app."
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isOnline",
+          "value": "boolean",
+          "description": "`true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes)."
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "AdapterRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface BeginParams extends AdapterArgs {\n  /** A Shopify domain name in the form `{exampleshop}.myshopify.com`. */\n  shop: string;\n  /** The path to the callback endpoint, with a leading `/`. This URL must be allowed in the Partners dashboard, or using the CLI to run your app. */\n  callbackPath: string;\n  /** `true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes). */\n  isOnline: boolean;\n}"
+    }
+  },
+  "CallbackParams": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "CallbackParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isOnline",
+          "value": "boolean",
+          "description": "Deprecated as of `v6.0.1`. Session type is automatically detected from response.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "AdapterRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface CallbackParams extends AdapterArgs {\n  /** Deprecated as of `v6.0.1`. Session type is automatically detected from response. */\n  isOnline?: boolean;\n}"
+    }
+  },
+  "AccessTokenResponse": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "AccessTokenResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "access_token",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scope",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface AccessTokenResponse {\n  access_token: string;\n  scope: string;\n}"
+    }
+  },
+  "OnlineAccessInfo": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "OnlineAccessInfo",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "expires_in",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "associated_user_scope",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "associated_user",
+          "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
+          "description": ""
+        }
+      ],
+      "value": "export interface OnlineAccessInfo {\n  expires_in: number;\n  associated_user_scope: string;\n  associated_user: {\n    id: number;\n    first_name: string;\n    last_name: string;\n    email: string;\n    email_verified: boolean;\n    account_owner: boolean;\n    locale: string;\n    collaborator: boolean;\n  };\n}"
+    }
+  },
+  "OnlineAccessResponse": {
+    "/auth/oauth/types.ts": {
+      "filePath": "/auth/oauth/types.ts",
+      "name": "OnlineAccessResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "access_token",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scope",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "expires_in",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "associated_user_scope",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "associated_user",
+          "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
+          "description": ""
+        }
+      ],
+      "value": "export interface OnlineAccessResponse\n  extends AccessTokenResponse,\n    OnlineAccessInfo {}"
+    }
+  },
+  "CryptoGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/crypto.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/crypto.ts",
+      "name": "CryptoGeneratedType",
+      "value": "crypto: Crypto"
+    }
+  },
+  "SetCryptoGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/crypto.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/crypto.ts",
+      "name": "SetCryptoGeneratedType",
+      "params": [
+        {
+          "name": "providedCrypto",
+          "description": "",
+          "value": "Crypto",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/crypto.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/crypto.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setCrypto(providedCrypto: Crypto) {\n  crypto = providedCrypto;\n}"
+    }
+  },
+  "HashFormat": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "HashFormat",
+      "value": "export enum HashFormat {\n  Base64 = 'base64',\n  Hex = 'hex',\n}",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/types.ts",
+          "name": "Base64",
+          "value": "base64"
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/types.ts",
+          "name": "Hex",
+          "value": "hex"
+        }
+      ]
+    }
+  },
+  "CreateSHA256HMACGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+      "name": "CreateSHA256HMACGeneratedType",
+      "params": [
+        {
+          "name": "secret",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        },
+        {
+          "name": "payload",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        },
+        {
+          "name": "returnFormat",
+          "description": "",
+          "value": "HashFormat",
+          "isOptional": true,
+          "defaultValue": "HashFormat.Base64",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+        "description": "",
+        "name": "Promise<string>",
+        "value": "Promise<string>"
+      },
+      "value": "export async function createSHA256HMAC(\n  secret: string,\n  payload: string,\n  returnFormat: HashFormat = HashFormat.Base64,\n): Promise<string> {\n  const cryptoLib =\n    typeof (crypto as any)?.webcrypto === 'undefined'\n      ? crypto\n      : (crypto as any).webcrypto;\n\n  // eslint-disable-next-line no-warning-comments\n  // TODO Make the subtle implementation the default when dropping Node 14 support\n  if (cryptoLib?.subtle) {\n    const enc = new TextEncoder();\n    const key = await cryptoLib.subtle.importKey(\n      'raw',\n      enc.encode(secret),\n      {\n        name: 'HMAC',\n        hash: {name: 'SHA-256'},\n      },\n      false,\n      ['sign'],\n    );\n\n    const signature = await cryptoLib.subtle.sign(\n      'HMAC',\n      key,\n      enc.encode(payload),\n    );\n    return returnFormat === HashFormat.Base64\n      ? asBase64(signature)\n      : asHex(signature);\n  }\n\n  return (cryptoLib as any)\n    .createHmac('sha256', secret)\n    .update(payload)\n    .digest(returnFormat);\n}"
+    }
+  },
+  "AsHexGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+      "name": "AsHexGeneratedType",
+      "params": [
+        {
+          "name": "buffer",
+          "description": "",
+          "value": "ArrayBuffer",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function asHex(buffer: ArrayBuffer): string {\n  return [...new Uint8Array(buffer)]\n    .map((byte) => byte.toString(16).padStart(2, '0'))\n    .join('');\n}"
+    }
+  },
+  "LookupTableGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+      "name": "LookupTableGeneratedType",
+      "value": "LookupTable =\n  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='"
+    }
+  },
+  "AsBase64GeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+      "name": "AsBase64GeneratedType",
+      "params": [
+        {
+          "name": "buffer",
+          "description": "",
+          "value": "ArrayBuffer",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function asBase64(buffer: ArrayBuffer): string {\n  let output = '';\n\n  const input = new Uint8Array(buffer);\n  for (let i = 0; i < input.length; ) {\n    const byte1 = input[i++];\n    const byte2 = input[i++];\n    const byte3 = input[i++];\n\n    const enc1 = byte1 >> 2;\n    const enc2 = ((byte1 & 0b00000011) << 4) | (byte2 >> 4);\n    let enc3 = ((byte2 & 0b00001111) << 2) | (byte3 >> 6);\n    let enc4 = byte3 & 0b00111111;\n\n    if (isNaN(byte2)) {\n      enc3 = 64;\n    }\n    if (isNaN(byte3)) {\n      enc4 = 64;\n    }\n\n    output +=\n      LookupTable[enc1] +\n      LookupTable[enc2] +\n      LookupTable[enc3] +\n      LookupTable[enc4];\n  }\n  return output;\n}"
+    }
+  },
+  "HashStringGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+      "name": "HashStringGeneratedType",
+      "params": [
+        {
+          "name": "str",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        },
+        {
+          "name": "returnFormat",
+          "description": "",
+          "value": "HashFormat",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/crypto/utils.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function hashString(str: string, returnFormat: HashFormat): string {\n  const buffer = new TextEncoder().encode(str);\n\n  switch (returnFormat) {\n    case HashFormat.Base64:\n      return asBase64(buffer);\n    case HashFormat.Hex:\n      return asHex(buffer);\n    default:\n      throw new ShopifyError(`Unrecognized hash format '${returnFormat}'`);\n  }\n}"
+    }
+  },
+  "SplitNGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/utils.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/utils.ts",
+      "name": "SplitNGeneratedType",
+      "params": [
+        {
+          "name": "str",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/utils.ts"
+        },
+        {
+          "name": "sep",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/utils.ts"
+        },
+        {
+          "name": "maxNumParts",
+          "description": "",
+          "value": "number",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/utils.ts",
+        "description": "",
+        "name": "string[]",
+        "value": "string[]"
+      },
+      "value": "export function splitN(\n  str: string,\n  sep: string,\n  maxNumParts: number,\n): string[] {\n  const parts = str.split(sep);\n  const maxParts = Math.min(Math.abs(maxNumParts), parts.length);\n\n  return [...parts.slice(0, maxParts - 1), parts.slice(maxParts - 1).join(sep)];\n}"
+    }
+  },
+  "CanonicalizeHeaderNameGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "CanonicalizeHeaderNameGeneratedType",
+      "params": [
+        {
+          "name": "hdr",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function canonicalizeHeaderName(hdr: string): string {\n  return hdr.replace(\n    /(^|-)(\\w+)/g,\n    (_fullMatch, start, letters) =>\n      start +\n      letters.slice(0, 1).toUpperCase() +\n      letters.slice(1).toLowerCase(),\n  );\n}"
+    }
+  },
+  "GetHeadersGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "GetHeadersGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "needle_",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "string[]",
+        "value": "string[]"
+      },
+      "value": "export function getHeaders(\n  headers: Headers | undefined,\n  needle_: string,\n): string[] {\n  const result: string[] = [];\n  if (!headers) return result;\n  const needle = canonicalizeHeaderName(needle_);\n  for (const [key, values] of Object.entries(headers)) {\n    if (canonicalizeHeaderName(key) !== needle) continue;\n    if (Array.isArray(values)) {\n      result.push(...values);\n    } else {\n      result.push(values);\n    }\n  }\n  return result;\n}"
+    }
+  },
+  "GetHeaderGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "GetHeaderGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "needle",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "string | undefined",
+        "value": "string | undefined"
+      },
+      "value": "export function getHeader(\n  headers: Headers | undefined,\n  needle: string,\n): string | undefined {\n  if (!headers) return undefined;\n  return getHeaders(headers, needle)?.[0];\n}"
+    }
+  },
+  "SetHeaderGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "SetHeaderGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "key",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setHeader(headers: Headers, key: string, value: string) {\n  canonicalizeHeaders(headers);\n  headers[canonicalizeHeaderName(key)] = [value];\n}"
+    }
+  },
+  "AddHeaderGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "AddHeaderGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "key",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function addHeader(headers: Headers, key: string, value: string) {\n  canonicalizeHeaders(headers);\n  const canonKey = canonicalizeHeaderName(key);\n  let list = headers[canonKey];\n  if (!list) {\n    list = [];\n  } else if (!Array.isArray(list)) {\n    list = [list];\n  }\n  headers[canonKey] = list;\n  list.push(value);\n}"
+    }
+  },
+  "CanonicalizeValueGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "CanonicalizeValueGeneratedType",
+      "params": [
+        {
+          "name": "value",
+          "description": "",
+          "value": "any",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "any",
+        "value": "any"
+      },
+      "value": "function canonicalizeValue(value: any): any {\n  if (typeof value === 'number') return value.toString();\n  return value;\n}"
+    }
+  },
+  "CanonicalizeHeadersGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "CanonicalizeHeadersGeneratedType",
+      "params": [
+        {
+          "name": "hdr",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "Headers",
+        "value": "Headers"
+      },
+      "value": "export function canonicalizeHeaders(hdr: Headers): Headers {\n  for (const [key, values] of Object.entries(hdr)) {\n    const canonKey = canonicalizeHeaderName(key);\n    if (!hdr[canonKey]) hdr[canonKey] = [];\n    if (!Array.isArray(hdr[canonKey]))\n      hdr[canonKey] = [canonicalizeValue(hdr[canonKey])];\n    if (key === canonKey) continue;\n    delete hdr[key];\n    (hdr[canonKey] as any).push(\n      ...[values].flat().map((value) => canonicalizeValue(value)),\n    );\n  }\n  return hdr;\n}"
+    }
+  },
+  "RemoveHeaderGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "RemoveHeaderGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        },
+        {
+          "name": "needle",
+          "description": "",
+          "value": "string",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function removeHeader(headers: Headers, needle: string) {\n  canonicalizeHeaders(headers);\n  const canonKey = canonicalizeHeaderName(needle);\n  delete headers[canonKey];\n}"
+    }
+  },
+  "FlatHeadersGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+      "name": "FlatHeadersGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/headers.ts",
+        "description": "",
+        "name": "[string, string][]",
+        "value": "[string, string][]"
+      },
+      "value": "export function flatHeaders(headers: Headers): [string, string][] {\n  return Object.entries(headers).flatMap(([header, values]) =>\n    Array.isArray(values)\n      ? values.map((value): [string, string] => [header, value])\n      : [[header, values]],\n  );\n}"
+    }
+  },
+  "CookieData": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+      "name": "CookieData",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "value",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "maxAge",
+          "value": "number",
+          "description": "a number representing the milliseconds from Date.now() for expiry",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "expires",
+          "value": "Date",
+          "description": "a Date object indicating the cookie's expiration\ndate (expires at the end of session by default).",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": "a string indicating the path of the cookie (/ by default).",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "domain",
+          "value": "string",
+          "description": "a string indicating the domain of the cookie (no default).",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "secure",
+          "value": "boolean",
+          "description": "a boolean indicating whether the cookie is only to be sent\nover HTTPS (false by default for HTTP, true by default for HTTPS).",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "httpOnly",
+          "value": "boolean",
+          "description": "a boolean indicating whether the cookie is only to be sent over HTTP(S),\nand not made available to client JavaScript (true by default).",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sameSite",
+          "value": "\"strict\" | \"lax\" | \"none\"",
+          "description": "a boolean or string indicating whether the cookie is a \"same site\" cookie (false by default).\nThis can be set to 'strict', 'lax', or true (which maps to 'strict').",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface CookieData {\n  name: string;\n  value: string;\n  /**\n   * a number representing the milliseconds from Date.now() for expiry\n   */\n  maxAge?: number;\n  /**\n   * a Date object indicating the cookie's expiration\n   * date (expires at the end of session by default).\n   */\n  expires?: Date;\n  /**\n   * a string indicating the path of the cookie (/ by default).\n   */\n  path?: string;\n  /**\n   * a string indicating the domain of the cookie (no default).\n   */\n  domain?: string;\n  /**\n   * a boolean indicating whether the cookie is only to be sent\n   * over HTTPS (false by default for HTTP, true by default for HTTPS).\n   */\n  secure?: boolean;\n  /**\n   * a boolean indicating whether the cookie is only to be sent over HTTP(S),\n   * and not made available to client JavaScript (true by default).\n   */\n  httpOnly?: boolean;\n  /**\n   * a boolean or string indicating whether the cookie is a \"same site\" cookie (false by default).\n   * This can be set to 'strict', 'lax', or true (which maps to 'strict').\n   */\n  sameSite?: 'strict' | 'lax' | 'none';\n}"
+    }
+  },
+  "CookieJar": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+      "name": "CookieJar",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "name": "[key: string]",
+          "value": "CookieData"
+        }
+      ],
+      "value": "export interface CookieJar {\n  [key: string]: CookieData;\n}"
+    }
+  },
+  "CookiesOptions": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+      "name": "CookiesOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "keys",
+          "value": "string[]",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/cookies.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "secure",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface CookiesOptions {\n  keys: string[];\n  // Ignored. Only for type-compatibility with the node package for now.\n  secure: boolean;\n}"
+    }
+  },
+  "IsOKGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "IsOKGeneratedType",
+      "params": [
+        {
+          "name": "resp",
+          "description": "",
+          "value": "NormalizedResponse",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function isOK(resp: NormalizedResponse) {\n  // https://fetch.spec.whatwg.org/#ok-status\n  return resp.statusCode >= 200 && resp.statusCode <= 299;\n}"
+    }
+  },
+  "AbstractFetchGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "AbstractFetchGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "abstractFetch: AbstractFetchFunc = () => {\n  throw new Error(\n    \"Missing adapter implementation for 'abstractFetch' - make sure to import the appropriate adapter for your platform\",\n  );\n}"
+    }
+  },
+  "SetAbstractFetchFuncGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "SetAbstractFetchFuncGeneratedType",
+      "params": [
+        {
+          "name": "func",
+          "description": "",
+          "value": "AbstractFetchFunc",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setAbstractFetchFunc(func: AbstractFetchFunc) {\n  abstractFetch = func;\n}"
+    }
+  },
+  "AbstractConvertRequestGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "AbstractConvertRequestGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "abstractConvertRequest: AbstractConvertRequestFunc = () => {\n  throw new Error(\n    \"Missing adapter implementation for 'abstractConvertRequest' - make sure to import the appropriate adapter for your platform\",\n  );\n}"
+    }
+  },
+  "SetAbstractConvertRequestFuncGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "SetAbstractConvertRequestFuncGeneratedType",
+      "params": [
+        {
+          "name": "func",
+          "description": "",
+          "value": "AbstractConvertRequestFunc",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setAbstractConvertRequestFunc(\n  func: AbstractConvertRequestFunc,\n) {\n  abstractConvertRequest = func;\n}"
+    }
+  },
+  "AbstractConvertIncomingResponseGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "AbstractConvertIncomingResponseGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "abstractConvertIncomingResponse: AbstractConvertIncomingResponseFunc =\n  () => Promise.resolve({} as NormalizedResponse)"
+    }
+  },
+  "SetAbstractConvertIncomingResponseFuncGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "SetAbstractConvertIncomingResponseFuncGeneratedType",
+      "params": [
+        {
+          "name": "func",
+          "description": "",
+          "value": "AbstractConvertIncomingResponseFunc",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setAbstractConvertIncomingResponseFunc(\n  func: AbstractConvertIncomingResponseFunc,\n) {\n  abstractConvertIncomingResponse = func;\n}"
+    }
+  },
+  "AbstractConvertResponseGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "AbstractConvertResponseGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "abstractConvertResponse: AbstractConvertResponseFunc = () => {\n  throw new Error(\n    \"Missing adapter implementation for 'abstractConvertResponse' - make sure to import the appropriate adapter for your platform\",\n  );\n}"
+    }
+  },
+  "SetAbstractConvertResponseFuncGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "SetAbstractConvertResponseFuncGeneratedType",
+      "params": [
+        {
+          "name": "func",
+          "description": "",
+          "value": "AbstractConvertResponseFunc",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setAbstractConvertResponseFunc(\n  func: AbstractConvertResponseFunc,\n) {\n  abstractConvertResponse = func;\n}"
+    }
+  },
+  "AbstractConvertHeadersGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "AbstractConvertHeadersGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "abstractConvertHeaders: AbstractConvertHeadersFunc = () => {\n  throw new Error(\n    \"Missing adapter implementation for 'abstractConvertHeaders' - make sure to import the appropriate adapter for your platform\",\n  );\n}"
+    }
+  },
+  "SetAbstractConvertHeadersFuncGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+      "name": "SetAbstractConvertHeadersFuncGeneratedType",
+      "params": [
+        {
+          "name": "func",
+          "description": "",
+          "value": "AbstractConvertHeadersFunc",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/http/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setAbstractConvertHeadersFunc(\n  func: AbstractConvertHeadersFunc,\n) {\n  abstractConvertHeaders = func;\n}"
+    }
+  },
+  "SessionParams": {
+    "/session/types.ts": {
+      "filePath": "/session/types.ts",
+      "name": "SessionParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "state",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isOnline",
+          "value": "boolean",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scope",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "expires",
+          "value": "Date",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "accessToken",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "onlineAccessInfo",
+          "value": "OnlineAccessInfo",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface SessionParams {\n  readonly id: string;\n  shop: string;\n  state: string;\n  isOnline: boolean;\n  scope?: string;\n  expires?: Date;\n  accessToken?: string;\n  onlineAccessInfo?: OnlineAccessInfo;\n}"
+    }
+  },
+  "JwtPayload": {
+    "/session/types.ts": {
+      "filePath": "/session/types.ts",
+      "name": "JwtPayload",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "iss",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "dest",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "aud",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sub",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "exp",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "nbf",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "iat",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "jti",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sid",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface JwtPayload {\n  iss: string;\n  dest: string;\n  aud: string;\n  sub: string;\n  exp: number;\n  nbf: number;\n  iat: number;\n  jti: string;\n  sid: string;\n}"
+    }
+  },
+  "GetCurrentSessionIdParams": {
+    "/session/types.ts": {
+      "filePath": "/session/types.ts",
+      "name": "GetCurrentSessionIdParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isOnline",
+          "value": "boolean",
+          "description": "Whether to look for an offline or online session, depending on how the [`auth.begin`](/docs/api/shopify-api-js/auth/begin) method was called."
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "AdapterRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "/session/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface GetCurrentSessionIdParams extends AdapterArgs {\n  /** Whether to look for an offline or online session, depending on how the [`auth.begin`](/docs/api/shopify-api-js/auth/begin) method was called. */\n  isOnline: boolean;\n}"
+    }
+  },
+  "PropertiesToSaveGeneratedType": {
+    "/session/session.ts": {
+      "filePath": "/session/session.ts",
+      "name": "PropertiesToSaveGeneratedType",
+      "value": "propertiesToSave = [\n  'id',\n  'shop',\n  'state',\n  'isOnline',\n  'scope',\n  'accessToken',\n  'expires',\n  'onlineAccessInfo',\n]"
+    }
+  },
+  "LogSeverity": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "LogSeverity",
+      "value": "export enum LogSeverity {\n  Error,\n  Warning,\n  Info,\n  Debug,\n}",
+      "members": [
+        {
+          "filePath": "/types.ts",
+          "name": "Error",
+          "value": 0
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Warning",
+          "value": 1
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Info",
+          "value": 2
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Debug",
+          "value": 3
+        }
+      ]
+    }
+  },
+  "ApiVersion": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "ApiVersion",
+      "value": "export enum ApiVersion {\n  January22 = '2022-01',\n  April22 = '2022-04',\n  July22 = '2022-07',\n  October22 = '2022-10',\n  January23 = '2023-01',\n  Unstable = 'unstable',\n}",
+      "members": [
+        {
+          "filePath": "/types.ts",
+          "name": "January22",
+          "value": "2022-01"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "April22",
+          "value": "2022-04"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "July22",
+          "value": "2022-07"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "October22",
+          "value": "2022-10"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "January23",
+          "value": "2023-01"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Unstable",
+          "value": "unstable"
+        }
+      ]
+    }
+  },
+  "LIBRARY_NAMEGeneratedType": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "name": "LIBRARY_NAMEGeneratedType",
+      "value": "LIBRARY_NAME = 'Shopify API Library'"
+    }
+  },
+  "LATEST_API_VERSIONGeneratedType": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "name": "LATEST_API_VERSIONGeneratedType",
+      "value": "LATEST_API_VERSION = ApiVersion.January23"
+    }
+  },
+  "ShopifyHeader": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "ShopifyHeader",
+      "value": "export enum ShopifyHeader {\n  AccessToken = 'X-Shopify-Access-Token',\n  ApiVersion = 'X-Shopify-API-Version',\n  Domain = 'X-Shopify-Shop-Domain',\n  Hmac = 'X-Shopify-Hmac-Sha256',\n  Topic = 'X-Shopify-Topic',\n  WebhookId = 'X-Shopify-Webhook-Id',\n  StorefrontAccessToken = 'X-Shopify-Storefront-Access-Token',\n  StorefrontSDKVariant = 'X-SDK-Variant',\n  StorefrontSDKVersion = 'X-SDK-Version',\n}",
+      "members": [
+        {
+          "filePath": "/types.ts",
+          "name": "AccessToken",
+          "value": "X-Shopify-Access-Token"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "ApiVersion",
+          "value": "X-Shopify-API-Version"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Domain",
+          "value": "X-Shopify-Shop-Domain"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Hmac",
+          "value": "X-Shopify-Hmac-Sha256"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Topic",
+          "value": "X-Shopify-Topic"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "WebhookId",
+          "value": "X-Shopify-Webhook-Id"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "StorefrontAccessToken",
+          "value": "X-Shopify-Storefront-Access-Token"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "StorefrontSDKVariant",
+          "value": "X-SDK-Variant"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "StorefrontSDKVersion",
+          "value": "X-SDK-Version"
+        }
+      ]
+    }
+  },
+  "ClientType": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "ClientType",
+      "value": "export enum ClientType {\n  Rest = 'rest',\n  Graphql = 'graphql',\n}",
+      "members": [
+        {
+          "filePath": "/types.ts",
+          "name": "Rest",
+          "value": "rest"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Graphql",
+          "value": "graphql"
+        }
+      ]
+    }
+  },
+  "GdprTopicsGeneratedType": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "name": "GdprTopicsGeneratedType",
+      "value": "gdprTopics: string[] = [\n  'CUSTOMERS_DATA_REQUEST',\n  'CUSTOMERS_REDACT',\n  'SHOP_REDACT',\n]"
+    }
+  },
+  "BillingInterval": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "BillingInterval",
+      "value": "export enum BillingInterval {\n  OneTime = 'ONE_TIME',\n  Every30Days = 'EVERY_30_DAYS',\n  Annual = 'ANNUAL',\n  Usage = 'USAGE',\n}",
+      "members": [
+        {
+          "filePath": "/types.ts",
+          "name": "OneTime",
+          "value": "ONE_TIME"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Every30Days",
+          "value": "EVERY_30_DAYS"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Annual",
+          "value": "ANNUAL"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Usage",
+          "value": "USAGE"
+        }
+      ]
+    }
+  },
+  "RecurringBillingIntervals": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RecurringBillingIntervals",
+      "value": "RecurringBillingIntervals",
+      "description": ""
+    }
+  },
+  "BillingReplacementBehavior": {
+    "/types.ts": {
+      "filePath": "/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "BillingReplacementBehavior",
+      "value": "export enum BillingReplacementBehavior {\n  ApplyImmediately = 'APPLY_IMMEDIATELY',\n  ApplyOnNextBillingCycle = 'APPLY_ON_NEXT_BILLING_CYCLE',\n  Standard = 'STANDARD',\n}",
+      "members": [
+        {
+          "filePath": "/types.ts",
+          "name": "ApplyImmediately",
+          "value": "APPLY_IMMEDIATELY"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "ApplyOnNextBillingCycle",
+          "value": "APPLY_ON_NEXT_BILLING_CYCLE"
+        },
+        {
+          "filePath": "/types.ts",
+          "name": "Standard",
+          "value": "STANDARD"
+        }
+      ]
+    }
+  },
+  "BillingConfigPlan": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "BillingConfigPlan",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface BillingConfigPlan {\n  amount: number;\n  currencyCode: string;\n}"
+    }
+  },
+  "BillingConfigOneTimePlan": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "BillingConfigOneTimePlan",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "interval",
+          "value": "BillingInterval.OneTime",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n  interval: BillingInterval.OneTime;\n}"
+    }
+  },
+  "BillingConfigSubscriptionPlan": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "BillingConfigSubscriptionPlan",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "interval",
+          "value": "RecurringBillingIntervals",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "trialDays",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "replacementBehavior",
+          "value": "BillingReplacementBehavior",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n  interval: RecurringBillingIntervals;\n  trialDays?: number;\n  replacementBehavior?: BillingReplacementBehavior;\n}"
+    }
+  },
+  "BillingConfigUsagePlan": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "BillingConfigUsagePlan",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "interval",
+          "value": "BillingInterval.Usage",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "usageTerms",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "trialDays",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "replacementBehavior",
+          "value": "BillingReplacementBehavior",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n  interval: BillingInterval.Usage;\n  usageTerms: string;\n  trialDays?: number;\n  replacementBehavior?: BillingReplacementBehavior;\n}"
+    }
+  },
+  "BillingConfig": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "BillingConfig",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "name": "[plan: string]",
+          "value": "| BillingConfigOneTimePlan\n    | BillingConfigSubscriptionPlan\n    | BillingConfigUsagePlan"
+        }
+      ],
+      "value": "export interface BillingConfig {\n  [plan: string]:\n    | BillingConfigOneTimePlan\n    | BillingConfigSubscriptionPlan\n    | BillingConfigUsagePlan;\n}"
+    }
+  },
+  "CheckParams": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "CheckParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The Session for the current request."
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plans",
+          "value": "string | string[]",
+          "description": "Name of plans to search."
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": "Whether to look for test purchases only. Defaults to `true`.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface CheckParams {\n  /** The Session for the current request. */\n  session: Session;\n  /** Name of plans to search. */\n  plans: string[] | string;\n  /** Whether to look for test purchases only. Defaults to `true`. */\n  isTest?: boolean;\n}"
+    }
+  },
+  "RequestParams": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "RequestParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The Session for the current request."
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plan",
+          "value": "string",
+          "description": "Name of plan to create a charge for."
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": "If `true`, Shopify will not actually charge for this purchase. Defaults to `true`.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface RequestParams {\n  /** The Session for the current request. */\n  session: Session;\n  /** Name of plan to create a charge for. */\n  plan: string;\n  /** If `true`, Shopify will not actually charge for this purchase. Defaults to `true`. */\n  isTest?: boolean;\n}"
+    },
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RequestParams",
+      "value": "(GetRequestParams | PostRequestParams) & {\n  method: Method;\n}",
+      "description": ""
+    }
+  },
+  "ActiveSubscription": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "ActiveSubscription",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "test",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface ActiveSubscription {\n  name: string;\n  test: boolean;\n}"
+    }
+  },
+  "ActiveSubscriptions": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "ActiveSubscriptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "activeSubscriptions",
+          "value": "ActiveSubscription[]",
+          "description": ""
+        }
+      ],
+      "value": "interface ActiveSubscriptions {\n  activeSubscriptions: ActiveSubscription[];\n}"
+    }
+  },
+  "OneTimePurchase": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "OneTimePurchase",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "name",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "test",
+          "value": "boolean",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "status",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "interface OneTimePurchase {\n  name: string;\n  test: boolean;\n  status: string;\n}"
+    }
+  },
+  "OneTimePurchases": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "OneTimePurchases",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "oneTimePurchases",
+          "value": "{ edges: { node: OneTimePurchase; }[]; pageInfo: { endCursor: string; hasNextPage: boolean; }; }",
+          "description": ""
+        }
+      ],
+      "value": "interface OneTimePurchases {\n  oneTimePurchases: {\n    edges: {\n      node: OneTimePurchase;\n    }[];\n    pageInfo: {\n      endCursor: string;\n      hasNextPage: boolean;\n    };\n  };\n}"
+    }
+  },
+  "CurrentAppInstallation": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CurrentAppInstallation",
+      "value": "OneTimePurchases & ActiveSubscriptions",
+      "description": ""
+    }
+  },
+  "CurrentAppInstallations": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "CurrentAppInstallations",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "userErrors",
+          "value": "string[]",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ currentAppInstallation: CurrentAppInstallation; }",
+          "description": ""
+        }
+      ],
+      "value": "export interface CurrentAppInstallations {\n  userErrors: string[];\n  data: {\n    currentAppInstallation: CurrentAppInstallation;\n  };\n}"
+    }
+  },
+  "RequestResponse": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "RequestResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "userErrors",
+          "value": "string[]",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "confirmationUrl",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface RequestResponse {\n  userErrors: string[];\n  confirmationUrl: string;\n}"
+    }
+  },
+  "RecurringPaymentResponse": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "RecurringPaymentResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ appSubscriptionCreate: RequestResponse; }",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "errors",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface RecurringPaymentResponse {\n  data: {\n    appSubscriptionCreate: RequestResponse;\n  };\n  errors?: string[];\n}"
+    }
+  },
+  "SinglePaymentResponse": {
+    "/billing/types.ts": {
+      "filePath": "/billing/types.ts",
+      "name": "SinglePaymentResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ appPurchaseOneTimeCreate: RequestResponse; }",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "errors",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface SinglePaymentResponse {\n  data: {\n    appPurchaseOneTimeCreate: RequestResponse;\n  };\n  errors?: string[];\n}"
+    }
+  },
+  "LogFunction": {
+    "/base-types.ts": {
+      "filePath": "/base-types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "LogFunction",
+      "value": "(severity: LogSeverity, msg: string) => Promise<void>",
+      "description": ""
+    }
+  },
+  "ConfigParams": {
+    "/base-types.ts": {
+      "filePath": "/base-types.ts",
+      "name": "ConfigParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiKey",
+          "value": "string",
+          "description": "API key for the app. You can find it in the Partners Dashboard."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiSecretKey",
+          "value": "string",
+          "description": "API secret key for the app. You can find it in the Partners Dashboard."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scopes",
+          "value": "string[] | AuthScopes",
+          "description": "[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hostName",
+          "value": "string",
+          "description": "App host name in the format `my-host-name.com`. Do not include the scheme or leading or trailing slashes."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hostScheme",
+          "value": "\"http\" | \"https\"",
+          "description": "The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "API version your app will be querying, e.g., `ApiVersion.October22`. Defaults to `LATEST_API_VERSION`"
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isEmbeddedApp",
+          "value": "boolean",
+          "description": "Whether your app will run within the Shopify Admin. Defaults to `true`. Learn more about embedded apps with [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup)"
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isCustomStoreApp",
+          "value": "boolean",
+          "description": "Whether you are building a custom app for a store. Defaults to `false`.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "userAgentPrefix",
+          "value": "string",
+          "description": "Any prefix you wish to include in the User-Agent for requests made by the library. Defaults to `undefined`",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "privateAppStorefrontAccessToken",
+          "value": "string",
+          "description": "Fixed Storefront API access token for custom store apps. Defaults to `undefined`",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customShopDomains",
+          "value": "(string | RegExp)[]",
+          "description": "Use this if you need to allow values other than myshopify.com. Defaults to `undefined`",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billing",
+          "value": "BillingConfig",
+          "description": "Billing configurations. Defaults to `undefined`. See [documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/billing.md) for full description.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "restResources",
+          "value": "T",
+          "description": "Mounts the given REST resources onto the object. Note: Must use the same version as `apiVersion`. Learn more about [using REST resources](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/rest-resources.md)",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "logger",
+          "value": "{ log?: LogFunction; level?: LogSeverity; httpRequests?: boolean; timestamps?: boolean; }",
+          "description": "Tweaks the behaviour of the package's internal logging to make it easier to debug applications.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface ConfigParams<T extends ShopifyRestResources = any> {\n  /** API key for the app. You can find it in the Partners Dashboard. */\n  apiKey: string;\n  /** API secret key for the app. You can find it in the Partners Dashboard. */\n  apiSecretKey: string;\n  /** [Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app. */\n  scopes: string[] | AuthScopes;\n  /** App host name in the format `my-host-name.com`. Do not include the scheme or leading or trailing slashes. */\n  hostName: string;\n  /** The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`. */\n  hostScheme?: 'http' | 'https';\n  /** API version your app will be querying, e.g., `ApiVersion.October22`. Defaults to `LATEST_API_VERSION` */\n  apiVersion: ApiVersion;\n  /** Whether your app will run within the Shopify Admin. Defaults to `true`. Learn more about embedded apps with [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup) */\n  isEmbeddedApp: boolean;\n  /** Whether you are building a custom app for a store. Defaults to `false`. */\n  isCustomStoreApp?: boolean;\n  /** Any prefix you wish to include in the User-Agent for requests made by the library. Defaults to `undefined` */\n  userAgentPrefix?: string;\n  /** Fixed Storefront API access token for custom store apps. Defaults to `undefined` */\n  privateAppStorefrontAccessToken?: string;\n  /** Use this if you need to allow values other than myshopify.com. Defaults to `undefined` */\n  customShopDomains?: (RegExp | string)[];\n  /** Billing configurations. Defaults to `undefined`. See [documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/billing.md) for full description. */\n  billing?: BillingConfig;\n  /** Mounts the given REST resources onto the object. Note: Must use the same version as `apiVersion`. Learn more about [using REST resources](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/rest-resources.md) */\n  restResources?: T;\n  /** Tweaks the behaviour of the package's internal logging to make it easier to debug applications. */\n  logger?: {\n    /** Async callback function used for logging, which takes in a `LogSeverity` value and a formatted message. Defaults to using console calls matching the severity parameter. */\n    log?: LogFunction;\n    /** Minimum severity for which to trigger the log function. Defaults to `LogSeverity.Info`. */\n    level?: LogSeverity;\n    /** Whether or not to log ALL HTTP requests made by the package. Defaults to `false`. Note: Only takes effect if `level` is set to `LogSeverity.Debug`. */\n    httpRequests?: boolean;\n    /** Whether or not to add the current timestamp to every logged message. Defaults to `false`. */\n    timestamps?: boolean;\n  };\n}"
+    }
+  },
+  "ConfigInterface": {
+    "/base-types.ts": {
+      "filePath": "/base-types.ts",
+      "name": "ConfigInterface",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hostScheme",
+          "value": "\"http\" | \"https\"",
+          "description": "The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scopes",
+          "value": "AuthScopes",
+          "description": "[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isCustomStoreApp",
+          "value": "boolean",
+          "description": "Whether you are building a custom app for a store. Defaults to `false`."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "logger",
+          "value": "{ log: LogFunction; level: LogSeverity; httpRequests: boolean; timestamps: boolean; }",
+          "description": "Tweaks the behaviour of the package's internal logging to make it easier to debug applications."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiKey",
+          "value": "string",
+          "description": "API key for the app. You can find it in the Partners Dashboard."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiSecretKey",
+          "value": "string",
+          "description": "API secret key for the app. You can find it in the Partners Dashboard."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scopes",
+          "value": "string[] | AuthScopes",
+          "description": "[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hostName",
+          "value": "string",
+          "description": "App host name in the format `my-host-name.com`. Do not include the scheme or leading or trailing slashes."
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hostScheme",
+          "value": "\"http\" | \"https\"",
+          "description": "The scheme for your app's public URL. Defaults to `\"https\"`. `\"http\"` is only allowed if your app is running on `localhost`.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "API version your app will be querying, e.g., `ApiVersion.October22`. Defaults to `LATEST_API_VERSION`"
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isEmbeddedApp",
+          "value": "boolean",
+          "description": "Whether your app will run within the Shopify Admin. Defaults to `true`. Learn more about embedded apps with [App Bridge](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup)"
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isCustomStoreApp",
+          "value": "boolean",
+          "description": "Whether you are building a custom app for a store. Defaults to `false`.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "userAgentPrefix",
+          "value": "string",
+          "description": "Any prefix you wish to include in the User-Agent for requests made by the library. Defaults to `undefined`",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "privateAppStorefrontAccessToken",
+          "value": "string",
+          "description": "Fixed Storefront API access token for custom store apps. Defaults to `undefined`",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customShopDomains",
+          "value": "(string | RegExp)[]",
+          "description": "Use this if you need to allow values other than myshopify.com. Defaults to `undefined`",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billing",
+          "value": "BillingConfig",
+          "description": "Billing configurations. Defaults to `undefined`. See [documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/billing.md) for full description.",
+          "isOptional": true
+        },
+        {
+          "filePath": "/base-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "logger",
+          "value": "{ log?: LogFunction; level?: LogSeverity; httpRequests?: boolean; timestamps?: boolean; }",
+          "description": "Tweaks the behaviour of the package's internal logging to make it easier to debug applications.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface ConfigInterface extends Omit<ConfigParams, 'restResources'> {\n  hostScheme: 'http' | 'https';\n  scopes: AuthScopes;\n  isCustomStoreApp: boolean;\n  logger: {\n    log: LogFunction;\n    level: LogSeverity;\n    httpRequests: boolean;\n    timestamps: boolean;\n  };\n}"
+    }
+  },
+  "SHOPIFY_API_LIBRARY_VERSIONGeneratedType": {
+    "/version.ts": {
+      "filePath": "/version.ts",
+      "name": "SHOPIFY_API_LIBRARY_VERSIONGeneratedType",
+      "value": "SHOPIFY_API_LIBRARY_VERSION = '6.2.0'"
+    }
+  },
+  "LogContext": {
+    "/logger/types.ts": {
+      "filePath": "/logger/types.ts",
+      "name": "LogContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/logger/types.ts",
+          "name": "[key: string]",
+          "value": "any"
+        }
+      ],
+      "value": "export interface LogContext {\n  [key: string]: any;\n}"
+    }
+  },
+  "LoggerFunction": {
+    "/logger/log.ts": {
+      "filePath": "/logger/log.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "LoggerFunction",
+      "value": "(\n  severity: LogSeverity,\n  message: string,\n  context?: {[key: string]: any},\n) => Promise<void>",
+      "description": ""
+    }
+  },
+  "LogGeneratedType": {
+    "/logger/log.ts": {
+      "filePath": "/logger/log.ts",
+      "name": "LogGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/logger/log.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/logger/log.ts",
+        "description": "",
+        "name": "LoggerFunction",
+        "value": "LoggerFunction"
+      },
+      "value": "export function log(config: ConfigInterface): LoggerFunction {\n  return async function (\n    severity: LogSeverity,\n    message: string,\n    context: LogContext = {},\n  ): Promise<void> {\n    if (severity > config.logger.level) {\n      return;\n    }\n\n    const prefix: string[] = [];\n\n    if (config.logger.timestamps) {\n      prefix.push(`${new Date().toISOString().slice(0, -5)}Z`);\n    }\n\n    let packageString = context.package || 'shopify-api';\n    delete context.package;\n\n    switch (severity) {\n      case LogSeverity.Debug:\n        packageString = `${packageString}/DEBUG`;\n        break;\n      case LogSeverity.Info:\n        packageString = `${packageString}/INFO`;\n        break;\n      case LogSeverity.Warning:\n        packageString = `${packageString}/WARNING`;\n        break;\n      case LogSeverity.Error:\n        packageString = `${packageString}/ERROR`;\n        break;\n    }\n\n    prefix.push(packageString);\n\n    const contextParts: string[] = [];\n    Object.entries(context).forEach(([key, value]) => {\n      contextParts.push(`${key}: ${value}`);\n    });\n\n    let suffix = '';\n    if (contextParts.length > 0) {\n      suffix = ` | {${contextParts.join(', ')}}`;\n    }\n\n    await config.logger.log(\n      severity,\n      `[${prefix.join('] [')}] ${message}${suffix}`,\n    );\n  };\n}"
+    }
+  },
+  "LoggerGeneratedType": {
+    "/logger/index.ts": {
+      "filePath": "/logger/index.ts",
+      "name": "LoggerGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/logger/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/logger/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function logger(config: ConfigInterface) {\n  const logFunction = log(config);\n\n  return {\n    log: logFunction,\n    debug: async (message: string, context: LogContext = {}) =>\n      logFunction(LogSeverity.Debug, message, context),\n    info: async (message: string, context: LogContext = {}) =>\n      logFunction(LogSeverity.Info, message, context),\n    warning: async (message: string, context: LogContext = {}) =>\n      logFunction(LogSeverity.Warning, message, context),\n    error: async (message: string, context: LogContext = {}) =>\n      logFunction(LogSeverity.Error, message, context),\n    deprecated: deprecated(logFunction),\n  };\n}"
+    }
+  },
+  "ShopifyLogger": {
+    "/logger/index.ts": {
+      "filePath": "/logger/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyLogger",
+      "value": "ReturnType<typeof logger>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/logger/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "log",
+          "value": "LoggerFunction",
+          "description": ""
+        },
+        {
+          "filePath": "/logger/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "debug",
+          "value": "(message: string, context?: LogContext) => Promise<void>",
+          "description": ""
+        },
+        {
+          "filePath": "/logger/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "info",
+          "value": "(message: string, context?: LogContext) => Promise<void>",
+          "description": ""
+        },
+        {
+          "filePath": "/logger/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "warning",
+          "value": "(message: string, context?: LogContext) => Promise<void>",
+          "description": ""
+        },
+        {
+          "filePath": "/logger/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "error",
+          "value": "(message: string, context?: LogContext) => Promise<void>",
+          "description": ""
+        },
+        {
+          "filePath": "/logger/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "deprecated",
+          "value": "(version: string, message: string) => Promise<void>",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "DeprecatedGeneratedType": {
+    "/logger/index.ts": {
+      "filePath": "/logger/index.ts",
+      "name": "DeprecatedGeneratedType",
+      "params": [
+        {
+          "name": "logFunction",
+          "description": "",
+          "value": "LoggerFunction",
+          "filePath": "/logger/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/logger/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "function deprecated(logFunction: LoggerFunction) {\n  return async function (version: string, message: string): Promise<void> {\n    if (semver.gte(SHOPIFY_API_LIBRARY_VERSION, version)) {\n      throw new FeatureDeprecatedError(\n        `Feature was deprecated in version ${version}`,\n      );\n    }\n\n    return logFunction(\n      LogSeverity.Warning,\n      `[Deprecated | ${version}] ${message}`,\n    );\n  };\n}"
+    }
+  },
+  "ValidateConfigGeneratedType": {
+    "/config.ts": {
+      "filePath": "/config.ts",
+      "name": "ValidateConfigGeneratedType",
+      "params": [
+        {
+          "name": "params",
+          "description": "",
+          "value": "ConfigParams<any>",
+          "filePath": "/config.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/config.ts",
+        "description": "",
+        "name": "ConfigInterface",
+        "value": "ConfigInterface"
+      },
+      "value": "export function validateConfig(params: ConfigParams<any>): ConfigInterface {\n  const config: ConfigInterface = {\n    apiKey: '',\n    apiSecretKey: '',\n    scopes: new AuthScopes([]),\n    hostName: '',\n    hostScheme: 'https',\n    apiVersion: LATEST_API_VERSION,\n    isEmbeddedApp: true,\n    isCustomStoreApp: false,\n    logger: {\n      log: defaultLogFunction,\n      level: LogSeverity.Info,\n      httpRequests: false,\n      timestamps: false,\n    },\n  };\n\n  // Make sure that the essential params actually have content in them\n  const mandatory: (keyof ConfigParams)[] = [\n    'apiKey',\n    'apiSecretKey',\n    'hostName',\n  ];\n  if (\n    (!('isCustomStoreApp' in params) || !params.isCustomStoreApp) &&\n    // DEPRECATION: isPrivateApp to be removed in 7.0.0\n    (!('isPrivateApp' in params) || !(params as any).isPrivateApp)\n  ) {\n    mandatory.push('scopes');\n  }\n  const missing: (keyof ConfigParams)[] = [];\n  mandatory.forEach((key) => {\n    if (!notEmpty(params[key])) {\n      missing.push(key);\n    }\n  });\n\n  if (missing.length) {\n    throw new ShopifyError(\n      `Cannot initialize Shopify API Library. Missing values for: ${missing.join(\n        ', ',\n      )}`,\n    );\n  }\n\n  const {\n    hostScheme,\n    isCustomStoreApp,\n    userAgentPrefix,\n    logger,\n    privateAppStorefrontAccessToken,\n    customShopDomains,\n    billing,\n    ...mandatoryParams\n  } = params;\n\n  Object.assign(config, mandatoryParams, {\n    hostName: params.hostName.replace(/\\/$/, ''),\n    scopes:\n      params.scopes instanceof AuthScopes\n        ? params.scopes\n        : new AuthScopes(params.scopes),\n    hostScheme: hostScheme ?? config.hostScheme,\n    isCustomStoreApp:\n      isCustomStoreApp === undefined\n        ? config.isCustomStoreApp\n        : isCustomStoreApp,\n    userAgentPrefix: userAgentPrefix ?? config.userAgentPrefix,\n    logger: {...config.logger, ...(logger || {})},\n    privateAppStorefrontAccessToken:\n      privateAppStorefrontAccessToken ?? config.privateAppStorefrontAccessToken,\n    customShopDomains: customShopDomains ?? config.customShopDomains,\n    billing: billing ?? config.billing,\n  });\n\n  if ('isPrivateApp' in params) {\n    createLogger(config).deprecated(\n      '7.0.0',\n      'The `isPrivateApp` config option has been deprecated. Please use `isCustomStoreApp` instead.',\n    );\n\n    // only set isCustomStoreApp to value of isPrivateApp, if isCustomStoreApp hasn't been set explicitly\n    if (!('isCustomStoreApp' in params)) {\n      config.isCustomStoreApp = (params as any).isPrivateApp;\n    }\n    delete (config as any).isPrivateApp;\n  }\n\n  return config;\n}"
+    }
+  },
+  "NotEmptyGeneratedType": {
+    "/config.ts": {
+      "filePath": "/config.ts",
+      "name": "NotEmptyGeneratedType",
+      "params": [
+        {
+          "name": "value",
+          "description": "",
+          "value": "T",
+          "filePath": "/config.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/config.ts",
+        "description": "",
+        "name": "value is NonNullable<T>",
+        "value": "value is NonNullable<T>"
+      },
+      "value": "function notEmpty<T>(value: T): value is NonNullable<T> {\n  if (value == null) {\n    return false;\n  }\n  return typeof value === 'string' || Array.isArray(value)\n    ? value.length > 0\n    : true;\n}"
+    }
+  },
+  "DefaultLogFunctionGeneratedType": {
+    "/config.ts": {
+      "filePath": "/config.ts",
+      "name": "DefaultLogFunctionGeneratedType",
+      "params": [
+        {
+          "name": "severity",
+          "description": "",
+          "value": "LogSeverity",
+          "filePath": "/config.ts"
+        },
+        {
+          "name": "message",
+          "description": "",
+          "value": "string",
+          "filePath": "/config.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/config.ts",
+        "description": "",
+        "name": "Promise<void>",
+        "value": "Promise<void>"
+      },
+      "value": "async function defaultLogFunction(\n  severity: LogSeverity,\n  message: string,\n): Promise<void> {\n  switch (severity) {\n    case LogSeverity.Debug:\n      console.debug(message);\n      break;\n    case LogSeverity.Info:\n      console.log(message);\n      break;\n    case LogSeverity.Warning:\n      console.warn(message);\n      break;\n    case LogSeverity.Error:\n      console.error(message);\n      break;\n  }\n}"
+    }
+  },
+  "DeprecatedV5Types": {
+    "/deprecated-v5-types.ts": {
+      "filePath": "/deprecated-v5-types.ts",
+      "name": "DeprecatedV5Types",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Context",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Context` is now `Shopify.config` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Auth",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Auth` is now `Shopify.auth` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Billing",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Billing` is now `Shopify.billing` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Session",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Session` is now `Shopify.session` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Clients",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Clients` is now `Shopify.clients` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Utils",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Utils` is now `Shopify.utils` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Webhooks",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Webhooks` is now `Shopify.webhooks` and its API has changed."
+        },
+        {
+          "filePath": "/deprecated-v5-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "Errors",
+          "value": "never",
+          "description": "",
+          "isOptional": true,
+          "deprecationMessage": "`Shopify.Errors` was deprecated, error classes are now exported directly from the package."
+        }
+      ],
+      "value": "export interface DeprecatedV5Types {\n  /**\n   * @deprecated\n   * `Shopify.Context` is now `Shopify.config` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md\n   */\n  Context?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Auth` is now `Shopify.auth` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-authentication-functions\n   */\n  Auth?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Billing` is now `Shopify.billing` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#billing\n   */\n  Billing?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Session` is now `Shopify.session` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-session-and-sessionstorage\n   */\n  Session?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Clients` is now `Shopify.clients` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-api-clients\n   */\n  Clients?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Utils` is now `Shopify.utils` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#utility-functions\n   */\n  Utils?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Webhooks` is now `Shopify.webhooks` and its API has changed.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#changes-to-webhook-functions\n   */\n  Webhooks?: never;\n\n  /**\n   * @deprecated\n   * `Shopify.Errors` was deprecated, error classes are now exported directly from the package.\n   *\n   * @see https://github.com/Shopify/shopify-api-js/blob/main/docs/migrating-to-v6.md#simplified-namespace-for-errors\n   */\n  Errors?: never;\n}"
+    }
+  },
+  "HeaderParams": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "name": "HeaderParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "name": "[key: string]",
+          "value": "string | number | string[]"
+        }
+      ],
+      "value": "export interface HeaderParams {\n  [key: string]: string | number | string[];\n}"
+    }
+  },
+  "DataType": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "DataType",
+      "value": "export enum DataType {\n  JSON = 'application/json',\n  GraphQL = 'application/graphql',\n  URLEncoded = 'application/x-www-form-urlencoded',\n}",
+      "members": [
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "name": "JSON",
+          "value": "application/json"
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "name": "GraphQL",
+          "value": "application/graphql"
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "name": "URLEncoded",
+          "value": "application/x-www-form-urlencoded"
+        }
+      ]
+    }
+  },
+  "QueryParams": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "QueryParams",
+      "value": "string | number | string[] | number[] | {[key: string]: QueryParams}",
+      "description": ""
+    }
+  },
+  "GetRequestParams": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "name": "GetRequestParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "DataType",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "string | { [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "{ [key: string]: QueryParams; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extraHeaders",
+          "value": "HeaderParams",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "tries",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface GetRequestParams {\n  path: string;\n  type?: DataType;\n  data?: {[key: string]: unknown} | string;\n  query?: {[key: string]: QueryParams};\n  extraHeaders?: HeaderParams;\n  tries?: number;\n}"
+    }
+  },
+  "PostRequestParams": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "PostRequestParams",
+      "value": "GetRequestParams & {\n  data: {[key: string]: unknown} | string;\n}",
+      "description": ""
+    }
+  },
+  "PutRequestParams": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "PutRequestParams",
+      "value": "PostRequestParams",
+      "description": ""
+    }
+  },
+  "DeleteRequestParams": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "DeleteRequestParams",
+      "value": "GetRequestParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "type",
+          "value": "DataType",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "string | { [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "{ [key: string]: QueryParams; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "extraHeaders",
+          "value": "HeaderParams",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "tries",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        }
+      ]
+    }
+  },
+  "RequestReturn": {
+    "/clients/http_client/types.ts": {
+      "filePath": "/clients/http_client/types.ts",
+      "name": "RequestReturn",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "T",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/http_client/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "Headers",
+          "description": ""
+        }
+      ],
+      "value": "export interface RequestReturn<T = unknown> {\n  body: T;\n  headers: Headers;\n}"
+    }
+  },
+  "AbstractRuntimeStringFunc": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/types.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AbstractRuntimeStringFunc",
+      "value": "() => string",
+      "description": ""
+    }
+  },
+  "AbstractRuntimeStringGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts",
+      "name": "AbstractRuntimeStringGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "abstractRuntimeString: AbstractRuntimeStringFunc = () => {\n  throw new Error(\n    \"Missing adapter implementation for 'abstractRuntimeString' - make sure to import the appropriate adapter for your platform\",\n  );\n}"
+    }
+  },
+  "SetAbstractRuntimeStringGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts",
+      "name": "SetAbstractRuntimeStringGeneratedType",
+      "params": [
+        {
+          "name": "func",
+          "description": "",
+          "value": "AbstractRuntimeStringFunc",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/runtime/platform/runtime-string.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function setAbstractRuntimeString(func: AbstractRuntimeStringFunc) {\n  abstractRuntimeString = func;\n}"
+    }
+  },
+  "DeprecationInterface": {
+    "/clients/http_client/http_client.ts": {
+      "filePath": "/clients/http_client/http_client.ts",
+      "name": "DeprecationInterface",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/http_client/http_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "message",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/http_client/http_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/http_client/http_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface DeprecationInterface {\n  message: string | null;\n  path: string;\n  body?: string;\n}"
+    }
+  },
+  "HttpClientParams": {
+    "/clients/http_client/http_client.ts": {
+      "filePath": "/clients/http_client/http_client.ts",
+      "name": "HttpClientParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/http_client/http_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "domain",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "interface HttpClientParams {\n  domain: string;\n}"
+    }
+  },
+  "HttpClientClassGeneratedType": {
+    "/clients/http_client/http_client.ts": {
+      "filePath": "/clients/http_client/http_client.ts",
+      "name": "HttpClientClassGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/clients/http_client/http_client.ts"
+        },
+        {
+          "name": "scheme",
+          "description": "",
+          "value": "string",
+          "isOptional": true,
+          "defaultValue": "'https'",
+          "filePath": "/clients/http_client/http_client.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/clients/http_client/http_client.ts",
+        "description": "",
+        "name": "typeof HttpClient",
+        "value": "typeof HttpClient"
+      },
+      "value": "export function httpClientClass(\n  config: ConfigInterface,\n  scheme = 'https',\n): typeof HttpClient {\n  class NewHttpClient extends HttpClient {\n    public static config = config;\n    public static scheme = scheme;\n  }\n\n  Reflect.defineProperty(NewHttpClient, 'name', {\n    value: 'HttpClient',\n  });\n\n  return NewHttpClient as typeof HttpClient;\n}"
+    }
+  },
+  "PageInfoParams": {
+    "/clients/rest/types.ts": {
+      "filePath": "/clients/rest/types.ts",
+      "name": "PageInfoParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "{ [key: string]: QueryParams; }",
+          "description": ""
+        }
+      ],
+      "value": "export interface PageInfoParams {\n  path: string;\n  query: {[key: string]: QueryParams};\n}"
+    }
+  },
+  "PageInfo": {
+    "/clients/rest/types.ts": {
+      "filePath": "/clients/rest/types.ts",
+      "name": "PageInfo",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "limit",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "fields",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "previousPageUrl",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "nextPageUrl",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "prevPage",
+          "value": "PageInfoParams",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "nextPage",
+          "value": "PageInfoParams",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface PageInfo {\n  limit: string;\n  fields?: string[];\n  previousPageUrl?: string;\n  nextPageUrl?: string;\n  prevPage?: PageInfoParams;\n  nextPage?: PageInfoParams;\n}"
+    }
+  },
+  "RestRequestReturn": {
+    "/clients/rest/types.ts": {
+      "filePath": "/clients/rest/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RestRequestReturn",
+      "value": "RequestReturn<T> & {\n  pageInfo?: PageInfo;\n}",
+      "description": ""
+    }
+  },
+  "RestClientParams": {
+    "/clients/rest/types.ts": {
+      "filePath": "/clients/rest/types.ts",
+      "name": "RestClientParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface RestClientParams {\n  session: Session;\n  apiVersion?: ApiVersion;\n}"
+    }
+  },
+  "RestClientClassParams": {
+    "/clients/rest/rest_client.ts": {
+      "filePath": "/clients/rest/rest_client.ts",
+      "name": "RestClientClassParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/rest_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": ""
+        }
+      ],
+      "value": "export interface RestClientClassParams {\n  config: ConfigInterface;\n}"
+    }
+  },
+  "RestClientClassGeneratedType": {
+    "/clients/rest/rest_client.ts": {
+      "filePath": "/clients/rest/rest_client.ts",
+      "name": "RestClientClassGeneratedType",
+      "params": [
+        {
+          "name": "params",
+          "description": "",
+          "value": "RestClientClassParams",
+          "filePath": "/clients/rest/rest_client.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/clients/rest/rest_client.ts",
+        "description": "",
+        "name": "typeof RestClient",
+        "value": "typeof RestClient"
+      },
+      "value": "export function restClientClass(\n  params: RestClientClassParams,\n): typeof RestClient {\n  const {config} = params;\n\n  class NewRestClient extends RestClient {\n    public static config = config;\n    public static scheme = 'https';\n  }\n\n  Reflect.defineProperty(NewRestClient, 'name', {\n    value: 'RestClient',\n  });\n\n  return NewRestClient as typeof RestClient;\n}"
+    }
+  },
+  "BaseFindArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+      "name": "BaseFindArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "params",
+          "value": "ParamSet",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "urlIds",
+          "value": "IdSet",
+          "description": ""
+        }
+      ],
+      "value": "interface BaseFindArgs {\n  session: Session;\n  params?: ParamSet;\n  urlIds: IdSet;\n}"
+    }
+  },
+  "BaseConstructorArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+      "name": "BaseConstructorArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "fromData",
+          "value": "Body",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface BaseConstructorArgs {\n  session: Session;\n  fromData?: Body | null;\n}"
+    }
+  },
+  "SaveArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+      "name": "SaveArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "update",
+          "value": "boolean",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface SaveArgs {\n  update?: boolean;\n}"
+    }
+  },
+  "RequestArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+      "name": "RequestArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "http_method",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "operation",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "Body",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "entity",
+          "value": "Base",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "params",
+          "value": "ParamSet",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "urlIds",
+          "value": "IdSet",
+          "description": ""
+        }
+      ],
+      "value": "interface RequestArgs extends BaseFindArgs {\n  http_method: string;\n  operation: string;\n  body?: Body | null;\n  entity?: Base | null;\n}"
+    }
+  },
+  "GetPathArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+      "name": "GetPathArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "http_method",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "operation",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "urlIds",
+          "value": "IdSet",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "entity",
+          "value": "Base",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface GetPathArgs {\n  http_method: string;\n  operation: string;\n  urlIds: IdSet;\n  entity?: Base | null;\n}"
+    }
+  },
+  "SetClassPropertiesArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+      "name": "SetClassPropertiesArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "CLIENT",
+          "value": "typeof RestClient",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/base.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "CONFIG",
+          "value": "ConfigInterface",
+          "description": ""
+        }
+      ],
+      "value": "interface SetClassPropertiesArgs {\n  CLIENT: typeof RestClient;\n  CONFIG: ConfigInterface;\n}"
+    }
+  },
+  "LoadRestResourcesParams": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts",
+      "name": "LoadRestResourcesParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "resources",
+          "value": "ShopifyRestResources",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "RestClient",
+          "value": "typeof RestClient",
+          "description": ""
+        }
+      ],
+      "value": "export interface LoadRestResourcesParams {\n  resources: ShopifyRestResources;\n  config: ConfigInterface;\n  RestClient: typeof RestClient;\n}"
+    }
+  },
+  "LoadRestResourcesGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts",
+      "name": "LoadRestResourcesGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "LoadRestResourcesParams",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/rest/load-rest-resources.ts",
+        "description": "",
+        "name": "ShopifyRestResources",
+        "value": "ShopifyRestResources"
+      },
+      "value": "export function loadRestResources({\n  resources,\n  config,\n  RestClient,\n}: LoadRestResourcesParams): ShopifyRestResources {\n  const firstResource = Object.keys(resources)[0];\n  if (config.apiVersion !== resources[firstResource].API_VERSION) {\n    logger(config).warning(\n      `Loading REST resources for API version ${resources[firstResource].API_VERSION}, which doesn't match the default ${config.apiVersion}`,\n    );\n  }\n\n  return Object.fromEntries(\n    Object.entries(resources).map(([name, resource]) => {\n      class NewResource extends resource {}\n\n      NewResource.setClassProperties({\n        CLIENT: RestClient,\n        CONFIG: config,\n      });\n\n      Object.entries(NewResource.HAS_ONE).map(([_attribute, klass]) => {\n        (klass as typeof Base).setClassProperties({\n          CLIENT: RestClient,\n          CONFIG: config,\n        });\n      });\n\n      Object.entries(NewResource.HAS_MANY).map(([_attribute, klass]) => {\n        (klass as typeof Base).setClassProperties({\n          CLIENT: RestClient,\n          CONFIG: config,\n        });\n      });\n\n      Reflect.defineProperty(NewResource, 'name', {\n        value: name,\n      });\n\n      return [name, NewResource];\n    }),\n  );\n}"
+    }
+  },
+  "GraphqlParams": {
+    "/clients/graphql/types.ts": {
+      "filePath": "/clients/graphql/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "GraphqlParams",
+      "value": "Omit<PostRequestParams, 'path' | 'type'>",
+      "description": "",
+      "members": []
+    }
+  },
+  "GraphqlClientParams": {
+    "/clients/graphql/types.ts": {
+      "filePath": "/clients/graphql/types.ts",
+      "name": "GraphqlClientParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface GraphqlClientParams {\n  session: Session;\n  apiVersion?: ApiVersion;\n}"
+    }
+  },
+  "StorefrontClientParams": {
+    "/clients/graphql/types.ts": {
+      "filePath": "/clients/graphql/types.ts",
+      "name": "StorefrontClientParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "domain",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storefrontAccessToken",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface StorefrontClientParams {\n  domain: string;\n  storefrontAccessToken: string;\n  apiVersion?: ApiVersion;\n}"
+    }
+  },
+  "GraphqlProxyParams": {
+    "/clients/graphql/types.ts": {
+      "filePath": "/clients/graphql/types.ts",
+      "name": "GraphqlProxyParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/graphql/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawBody",
+          "value": "string",
+          "description": ""
+        }
+      ],
+      "value": "export interface GraphqlProxyParams {\n  session: Session;\n  rawBody: string;\n}"
+    }
+  },
+  "GraphqlClientClassParams": {
+    "/clients/graphql/graphql_client.ts": {
+      "filePath": "/clients/graphql/graphql_client.ts",
+      "name": "GraphqlClientClassParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/graphql/graphql_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/graphql/graphql_client.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "HttpClient",
+          "value": "typeof HttpClient",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface GraphqlClientClassParams {\n  config: ConfigInterface;\n  HttpClient?: typeof HttpClient;\n}"
+    }
+  },
+  "GraphqlClientClassGeneratedType": {
+    "/clients/graphql/graphql_client.ts": {
+      "filePath": "/clients/graphql/graphql_client.ts",
+      "name": "GraphqlClientClassGeneratedType",
+      "params": [
+        {
+          "name": "params",
+          "description": "",
+          "value": "GraphqlClientClassParams",
+          "filePath": "/clients/graphql/graphql_client.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/clients/graphql/graphql_client.ts",
+        "description": "",
+        "name": "typeof GraphqlClient",
+        "value": "typeof GraphqlClient"
+      },
+      "value": "export function graphqlClientClass(\n  params: GraphqlClientClassParams,\n): typeof GraphqlClient {\n  const {config} = params;\n  let {HttpClient} = params;\n  if (!HttpClient) {\n    HttpClient = httpClientClass(params.config);\n  }\n\n  class NewGraphqlClient extends GraphqlClient {\n    public static config = config;\n    public static HttpClient = HttpClient!;\n  }\n\n  Reflect.defineProperty(NewGraphqlClient, 'name', {\n    value: 'GraphqlClient',\n  });\n\n  return NewGraphqlClient as typeof GraphqlClient;\n}"
+    }
+  },
+  "StorefrontClientClassGeneratedType": {
+    "/clients/graphql/storefront_client.ts": {
+      "filePath": "/clients/graphql/storefront_client.ts",
+      "name": "StorefrontClientClassGeneratedType",
+      "params": [
+        {
+          "name": "params",
+          "description": "",
+          "value": "GraphqlClientClassParams",
+          "filePath": "/clients/graphql/storefront_client.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/clients/graphql/storefront_client.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function storefrontClientClass(params: GraphqlClientClassParams) {\n  const {config} = params;\n  let {HttpClient} = params;\n  if (!HttpClient) {\n    HttpClient = httpClientClass(config);\n  }\n  class NewStorefrontClient extends StorefrontClient {\n    public static config = config;\n    public static HttpClient = HttpClient!;\n  }\n\n  Reflect.defineProperty(NewStorefrontClient, 'name', {\n    value: 'StorefrontClient',\n  });\n\n  return NewStorefrontClient as typeof StorefrontClient;\n}"
+    }
+  },
+  "GraphqlProxyGeneratedType": {
+    "/clients/graphql/graphql_proxy.ts": {
+      "filePath": "/clients/graphql/graphql_proxy.ts",
+      "name": "GraphqlProxyGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/clients/graphql/graphql_proxy.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/clients/graphql/graphql_proxy.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function graphqlProxy(config: ConfigInterface) {\n  return async ({\n    session,\n    rawBody,\n  }: GraphqlProxyParams): Promise<RequestReturn> => {\n    if (!session.accessToken) {\n      throw new ShopifyErrors.InvalidSession(\n        'Cannot proxy query. Session not authenticated.',\n      );\n    }\n\n    const GraphqlClient = graphqlClientClass({config});\n    const client = new GraphqlClient({session});\n    return client.query({\n      data: rawBody,\n    });\n  };\n}"
+    }
+  },
+  "ClientClassesGeneratedType": {
+    "/clients/index.ts": {
+      "filePath": "/clients/index.ts",
+      "name": "ClientClassesGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/clients/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/clients/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function clientClasses(config: ConfigInterface) {\n  const HttpClient = httpClientClass(config);\n  return {\n    // We don't pass in the HttpClient because the RestClient inherits from it, and goes through the same setup process\n    Rest: restClientClass({config}),\n    Graphql: graphqlClientClass({config, HttpClient}),\n    Storefront: storefrontClientClass({config, HttpClient}),\n    graphqlProxy: graphqlProxy(config),\n  };\n}"
+    }
+  },
+  "ShopifyClients": {
+    "/clients/index.ts": {
+      "filePath": "/clients/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyClients",
+      "value": "ReturnType<typeof clientClasses>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "Rest",
+          "value": "typeof RestClient",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "Graphql",
+          "value": "typeof GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "Storefront",
+          "value": "typeof StorefrontClient",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "graphqlProxy",
+          "value": "({ session, rawBody, }: GraphqlProxyParams) => Promise<RequestReturn<unknown>>",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "SafeCompareParam": {
+    "/auth/oauth/safe-compare.ts": {
+      "filePath": "/auth/oauth/safe-compare.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SafeCompareParam",
+      "value": "string | {[key: string]: string} | string[] | number[]",
+      "description": ""
+    }
+  },
+  "SafeCompareGeneratedType": {
+    "/auth/oauth/safe-compare.ts": {
+      "filePath": "/auth/oauth/safe-compare.ts",
+      "name": "SafeCompareGeneratedType",
+      "params": [
+        {
+          "name": "item1",
+          "description": "first value to compare",
+          "value": "SafeCompareParam",
+          "filePath": "/auth/oauth/safe-compare.ts"
+        },
+        {
+          "name": "item2",
+          "description": "second value to compare",
+          "value": "SafeCompareParam",
+          "filePath": "/auth/oauth/safe-compare.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/safe-compare.ts",
+        "description": "whether the two input values are equal",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "export function safeCompare(\n  item1: SafeCompareParam,\n  item2: SafeCompareParam,\n): boolean {\n  if (typeof item1 === typeof item2) {\n    const enc = new TextEncoder();\n    const buffA = enc.encode(JSON.stringify(item1));\n    const buffB = enc.encode(JSON.stringify(item2));\n\n    if (buffA.length === buffB.length) {\n      return timingSafeEqual(buffA, buffB);\n    }\n  } else {\n    throw new ShopifyErrors.SafeCompareError(\n      `Mismatched data types provided: ${typeof item1} and ${typeof item2}`,\n    );\n  }\n  return false;\n}"
+    }
+  },
+  "TimingSafeEqualGeneratedType": {
+    "/auth/oauth/safe-compare.ts": {
+      "filePath": "/auth/oauth/safe-compare.ts",
+      "name": "TimingSafeEqualGeneratedType",
+      "params": [
+        {
+          "name": "bufA",
+          "description": "",
+          "value": "ArrayBuffer",
+          "filePath": "/auth/oauth/safe-compare.ts"
+        },
+        {
+          "name": "bufB",
+          "description": "",
+          "value": "ArrayBuffer",
+          "filePath": "/auth/oauth/safe-compare.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/safe-compare.ts",
+        "description": "",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "function timingSafeEqual(bufA: ArrayBuffer, bufB: ArrayBuffer): boolean {\n  const viewA = new Uint8Array(bufA);\n  const viewB = new Uint8Array(bufB);\n  let out = 0;\n  for (let i = 0; i < viewA.length; i++) {\n    out |= viewA[i] ^ viewB[i];\n  }\n  return out === 0;\n}"
+    }
+  },
+  "HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SECGeneratedType": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "name": "HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SECGeneratedType",
+      "value": "HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC = 90"
+    }
+  },
+  "StringifyQueryGeneratedType": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "name": "StringifyQueryGeneratedType",
+      "params": [
+        {
+          "name": "query",
+          "description": "",
+          "value": "AuthQuery",
+          "filePath": "/utils/hmac-validator.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/hmac-validator.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "function stringifyQuery(query: AuthQuery): string {\n  const processedQuery = new ProcessedQuery();\n  Object.keys(query)\n    .sort((val1, val2) => val1.localeCompare(val2))\n    .forEach((key: string) => processedQuery.put(key, query[key]));\n\n  return processedQuery.stringify(true);\n}"
+    }
+  },
+  "GenerateLocalHmacGeneratedType": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "name": "GenerateLocalHmacGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/utils/hmac-validator.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/hmac-validator.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function generateLocalHmac(config: ConfigInterface) {\n  return async (params: AuthQuery): Promise<string> => {\n    const {hmac, ...query} = params;\n    const queryString = stringifyQuery(query);\n    return createSHA256HMAC(config.apiSecretKey, queryString, HashFormat.Hex);\n  };\n}"
+    }
+  },
+  "ValidateHmacResponse": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ValidateHmacResponse",
+      "value": "boolean",
+      "description": ""
+    }
+  },
+  "ValidateHmacFunction": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ValidateHmacFunction",
+      "value": "(query: AuthQuery) => Promise<ValidateHmacResponse>",
+      "description": ""
+    }
+  },
+  "ValidateHmacGeneratedType": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "name": "ValidateHmacGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/utils/hmac-validator.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/hmac-validator.ts",
+        "description": "Whether the `hmac` value in the query is valid.",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function validateHmac(config: ConfigInterface) {\n  return async (query: AuthQuery): Promise<ValidateHmacResponse> => {\n    if (!query.hmac) {\n      throw new ShopifyErrors.InvalidHmacError(\n        'Query does not contain an HMAC value.',\n      );\n    }\n\n    validateHmacTimestamp(query);\n\n    const {hmac} = query;\n    const localHmac = await generateLocalHmac(config)(query);\n\n    return safeCompare(hmac as string, localHmac);\n  };\n}"
+    }
+  },
+  "GetCurrentTimeInSecGeneratedType": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "name": "GetCurrentTimeInSecGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "/utils/hmac-validator.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getCurrentTimeInSec() {\n  return Math.trunc(Date.now() / 1000);\n}"
+    }
+  },
+  "ValidateHmacTimestampGeneratedType": {
+    "/utils/hmac-validator.ts": {
+      "filePath": "/utils/hmac-validator.ts",
+      "name": "ValidateHmacTimestampGeneratedType",
+      "params": [
+        {
+          "name": "query",
+          "description": "",
+          "value": "AuthQuery",
+          "filePath": "/utils/hmac-validator.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/hmac-validator.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "function validateHmacTimestamp(query: AuthQuery) {\n  if (\n    Math.abs(getCurrentTimeInSec() - Number(query.timestamp)) >\n    HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC\n  ) {\n    throw new ShopifyErrors.InvalidHmacError(\n      'HMAC timestamp is outside of the tolerance range',\n    );\n  }\n}"
+    }
+  },
+  "DecodeHostGeneratedType": {
+    "/auth/decode-host.ts": {
+      "filePath": "/auth/decode-host.ts",
+      "name": "DecodeHostGeneratedType",
+      "params": [
+        {
+          "name": "host",
+          "description": "",
+          "value": "string",
+          "filePath": "/auth/decode-host.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/decode-host.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function decodeHost(host: string): string {\n  // eslint-disable-next-line no-warning-comments\n  // TODO Remove the Buffer.from call when dropping Node 14 support\n  return typeof atob === 'undefined'\n    ? Buffer.from(host, 'base64').toString()\n    : atob(host);\n}"
+    }
+  },
+  "SanitizeShopParams": {
+    "/utils/shop-validator.ts": {
+      "filePath": "/utils/shop-validator.ts",
+      "name": "SanitizeShopParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/utils/shop-validator.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "string",
+          "description": "The shop to sanitize."
+        },
+        {
+          "filePath": "/utils/shop-validator.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "throwOnInvalid",
+          "value": "boolean",
+          "description": "Whether to throw an error if the shop is invalid. Defaults to `false`.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface SanitizeShopParams {\n  /** The shop to sanitize. */\n  shop: string;\n  /** Whether to throw an error if the shop is invalid. Defaults to `false`. */\n  throwOnInvalid?: boolean;\n}"
+    }
+  },
+  "SanitizeShopReturns": {
+    "/utils/shop-validator.ts": {
+      "filePath": "/utils/shop-validator.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SanitizeShopReturns",
+      "value": "string | null",
+      "description": ""
+    }
+  },
+  "SanitizeShopGeneratedType": {
+    "/utils/shop-validator.ts": {
+      "filePath": "/utils/shop-validator.ts",
+      "name": "SanitizeShopGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/utils/shop-validator.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/shop-validator.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function sanitizeShop(config: ConfigInterface) {\n  return (shop: string, throwOnInvalid = false): string | null => {\n    const domainsRegex = ['myshopify\\\\.com', 'shopify\\\\.com', 'myshopify\\\\.io'];\n    if (config.customShopDomains) {\n      domainsRegex.push(\n        ...config.customShopDomains.map((regex) =>\n          typeof regex === 'string' ? regex : regex.source,\n        ),\n      );\n    }\n\n    const shopUrlRegex = new RegExp(\n      `^[a-zA-Z0-9][a-zA-Z0-9-_]*\\\\.(${domainsRegex.join('|')})[/]*$`,\n    );\n\n    const sanitizedShop = shopUrlRegex.test(shop) ? shop : null;\n    if (!sanitizedShop && throwOnInvalid) {\n      throw new InvalidShopError('Received invalid shop argument');\n    }\n\n    return sanitizedShop;\n  };\n}"
+    }
+  },
+  "SanitizeHostParams": {
+    "/utils/shop-validator.ts": {
+      "filePath": "/utils/shop-validator.ts",
+      "name": "SanitizeHostParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/utils/shop-validator.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "host",
+          "value": "string",
+          "description": "The incoming host value to sanitize."
+        },
+        {
+          "filePath": "/utils/shop-validator.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "throwOnInvalid",
+          "value": "boolean",
+          "description": "Whether to throw an error if the host is invalid. Defaults to `false`.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface SanitizeHostParams {\n  /** The incoming host value to sanitize. */\n  host: string;\n  /** Whether to throw an error if the host is invalid. Defaults to `false`. */\n  throwOnInvalid?: boolean;\n}"
+    }
+  },
+  "SanitizeHostReturns": {
+    "/utils/shop-validator.ts": {
+      "filePath": "/utils/shop-validator.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SanitizeHostReturns",
+      "value": "string | null",
+      "description": ""
+    }
+  },
+  "SanitizeHostGeneratedType": {
+    "/utils/shop-validator.ts": {
+      "filePath": "/utils/shop-validator.ts",
+      "name": "SanitizeHostGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/utils/shop-validator.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/shop-validator.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function sanitizeHost(config: ConfigInterface) {\n  return (host: string, throwOnInvalid = false): string | null => {\n    const base64regex = /^[0-9a-zA-Z+/]+={0,2}$/;\n\n    let sanitizedHost = base64regex.test(host) ? host : null;\n    if (sanitizedHost) {\n      const url = new URL(`https://${decodeHost(sanitizedHost)}`);\n      if (!sanitizeShop(config)(url.hostname, false)) {\n        sanitizedHost = null;\n      }\n    }\n    if (!sanitizedHost && throwOnInvalid) {\n      throw new InvalidHostError('Received invalid host argument');\n    }\n\n    return sanitizedHost;\n  };\n}"
+    }
+  },
+  "GetHMACKeyGeneratedType": {
+    "/utils/get-hmac-key.ts": {
+      "filePath": "/utils/get-hmac-key.ts",
+      "name": "GetHMACKeyGeneratedType",
+      "params": [
+        {
+          "name": "key",
+          "description": "",
+          "value": "string",
+          "filePath": "/utils/get-hmac-key.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/get-hmac-key.ts",
+        "description": "",
+        "name": "Uint8Array",
+        "value": "Uint8Array"
+      },
+      "value": "export function getHMACKey(key: string): Uint8Array {\n  const arrayBuffer = new Uint8Array(key.length);\n  for (let i = 0, keyLen = key.length; i < keyLen; i++) {\n    arrayBuffer[i] = key.charCodeAt(i);\n  }\n\n  return arrayBuffer;\n}"
+    }
+  },
+  "JWT_PERMITTED_CLOCK_TOLERANCEGeneratedType": {
+    "/session/decode-session-token.ts": {
+      "filePath": "/session/decode-session-token.ts",
+      "name": "JWT_PERMITTED_CLOCK_TOLERANCEGeneratedType",
+      "value": "JWT_PERMITTED_CLOCK_TOLERANCE = 10"
+    }
+  },
+  "DecodeSessionTokenGeneratedType": {
+    "/session/decode-session-token.ts": {
+      "filePath": "/session/decode-session-token.ts",
+      "name": "DecodeSessionTokenGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/session/decode-session-token.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/decode-session-token.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function decodeSessionToken(config: ConfigInterface) {\n  return async (token: string): Promise<JwtPayload> => {\n    let payload: JwtPayload;\n    try {\n      payload = (\n        await jose.jwtVerify(token, getHMACKey(config.apiSecretKey), {\n          algorithms: ['HS256'],\n          clockTolerance: JWT_PERMITTED_CLOCK_TOLERANCE,\n        })\n      ).payload as unknown as JwtPayload;\n    } catch (error) {\n      throw new ShopifyErrors.InvalidJwtError(\n        `Failed to parse session token '${token}': ${error.message}`,\n      );\n    }\n\n    // The exp and nbf fields are validated by the JWT library\n\n    if (payload.aud !== config.apiKey) {\n      throw new ShopifyErrors.InvalidJwtError(\n        'Session token had invalid API key',\n      );\n    }\n\n    return payload;\n  };\n}"
+    }
+  },
+  "GetJwtSessionIdGeneratedType": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "name": "GetJwtSessionIdGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/session/session-utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/session-utils.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getJwtSessionId(config: ConfigInterface) {\n  return (shop: string, userId: string): string => {\n    return `${sanitizeShop(config)(shop, true)}_${userId}`;\n  };\n}"
+    }
+  },
+  "GetOfflineIdParams": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "name": "GetOfflineIdParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/session/session-utils.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "string",
+          "description": "The shop domain to use to build the session id."
+        }
+      ],
+      "value": "interface GetOfflineIdParams {\n  /** The shop domain to use to build the session id. */\n  shop: string;\n}"
+    }
+  },
+  "GetOfflineIdReturns": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "GetOfflineIdReturns",
+      "value": "string",
+      "description": ""
+    }
+  },
+  "GetOfflineIdFunction": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "GetOfflineIdFunction",
+      "value": "(shop: string) => string",
+      "description": "Builds a session id for offline sessions."
+    }
+  },
+  "GetOfflineIdCreatorGeneratedType": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "name": "GetOfflineIdCreatorGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/session/session-utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/session-utils.ts",
+        "description": "",
+        "name": "GetOfflineIdFunction",
+        "value": "GetOfflineIdFunction"
+      },
+      "value": "export function getOfflineIdCreator(\n  config: ConfigInterface,\n): GetOfflineIdFunction {\n  /**\n   * Builds a session id for offline sessions.\n   * @param {string} shop The shop domain to use to build the session id.\n   * @returns The session id.\n   */\n  return function getOfflineId(shop: string): string {\n    return `offline_${sanitizeShop(config)(shop, true)}`;\n  };\n}"
+    }
+  },
+  "GetCurrentIdReturns": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "GetCurrentIdReturns",
+      "value": "string | undefined",
+      "description": ""
+    }
+  },
+  "GetCurrentSessionIdGeneratedType": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "name": "GetCurrentSessionIdGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/session/session-utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/session-utils.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getCurrentSessionId(config: ConfigInterface) {\n  return async function getCurrentSessionId({\n    isOnline,\n    ...adapterArgs\n  }: GetCurrentSessionIdParams): Promise<string | undefined> {\n    const request = await abstractConvertRequest(adapterArgs);\n\n    const log = logger(config);\n\n    if (config.isEmbeddedApp) {\n      log.debug('App is embedded, looking for session id in JWT payload', {\n        isOnline,\n      });\n\n      const authHeader = request.headers.Authorization;\n      if (authHeader) {\n        const matches = (\n          typeof authHeader === 'string' ? authHeader : authHeader[0]\n        ).match(/^Bearer (.+)$/);\n        if (!matches) {\n          log.error('Missing Bearer token in authorization header', {isOnline});\n\n          throw new ShopifyErrors.MissingJwtTokenError(\n            'Missing Bearer token in authorization header',\n          );\n        }\n\n        const jwtPayload = await decodeSessionToken(config)(matches[1]);\n        const shop = jwtPayload.dest.replace(/^https:\\/\\//, '');\n\n        log.debug('Found valid JWT payload', {shop, isOnline});\n\n        if (isOnline) {\n          return getJwtSessionId(config)(shop, jwtPayload.sub);\n        } else {\n          return getOfflineId(config)(shop);\n        }\n      } else {\n        log.error(\n          'Missing Authorization header, was the request made with authenticatedFetch?',\n          {isOnline},\n        );\n      }\n    } else {\n      log.debug('App is not embedded, looking for session id in cookies', {\n        isOnline,\n      });\n\n      const cookies = new Cookies(request, {} as NormalizedResponse, {\n        keys: [config.apiSecretKey],\n      });\n      return cookies.getAndVerify(SESSION_COOKIE_NAME);\n    }\n\n    return undefined;\n  };\n}"
+    }
+  },
+  "CustomAppSessionGeneratedType": {
+    "/session/session-utils.ts": {
+      "filePath": "/session/session-utils.ts",
+      "name": "CustomAppSessionGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/session/session-utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/session-utils.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function customAppSession(config: ConfigInterface) {\n  return (shop: string): Session => {\n    return new Session({\n      id: '',\n      shop: `${sanitizeShop(config)(shop, true)}`,\n      state: '',\n      isOnline: false,\n    });\n  };\n}"
+    }
+  },
+  "NonceGeneratedType": {
+    "/auth/oauth/nonce.ts": {
+      "filePath": "/auth/oauth/nonce.ts",
+      "name": "NonceGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "/auth/oauth/nonce.ts",
+        "description": "A 15 character random string",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function nonce(): string {\n  const length = 15;\n\n  // eslint-disable-next-line no-warning-comments\n  // TODO Remove the randomBytes call when dropping Node 14 support\n  const bytes = crypto.getRandomValues\n    ? crypto.getRandomValues(new Uint8Array(length))\n    : (crypto as any).randomBytes(length);\n\n  const nonce = bytes\n    .map((byte: number) => {\n      return byte % 10;\n    })\n    .join('');\n\n  return nonce;\n}"
+    }
+  },
+  "CallbackResponse": {
+    "/auth/oauth/oauth.ts": {
+      "filePath": "/auth/oauth/oauth.ts",
+      "name": "CallbackResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/oauth/oauth.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "T",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/oauth/oauth.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        }
+      ],
+      "value": "export interface CallbackResponse<T = AdapterHeaders> {\n  headers: T;\n  session: Session;\n}"
+    }
+  },
+  "BeginGeneratedType": {
+    "/auth/oauth/oauth.ts": {
+      "filePath": "/auth/oauth/oauth.ts",
+      "name": "BeginGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/auth/oauth/oauth.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/oauth.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function begin(config: ConfigInterface) {\n  return async ({\n    shop,\n    callbackPath,\n    isOnline,\n    ...adapterArgs\n  }: BeginParams): Promise<AdapterResponse> => {\n    throwIfCustomStoreApp(\n      config.isCustomStoreApp,\n      'Cannot perform OAuth for private apps',\n    );\n\n    const log = logger(config);\n    log.info('Beginning OAuth', {shop, isOnline, callbackPath});\n\n    const cleanShop = sanitizeShop(config)(shop, true)!;\n    const request = await abstractConvertRequest(adapterArgs);\n    const response = await abstractConvertIncomingResponse(adapterArgs);\n\n    const cookies = new Cookies(request, response, {\n      keys: [config.apiSecretKey],\n      secure: true,\n    });\n\n    const state = nonce();\n\n    await cookies.setAndSign(STATE_COOKIE_NAME, state, {\n      expires: new Date(Date.now() + 60000),\n      sameSite: 'lax',\n      secure: true,\n      path: callbackPath,\n    });\n\n    const query = {\n      client_id: config.apiKey,\n      scope: config.scopes.toString(),\n      redirect_uri: `${config.hostScheme}://${config.hostName}${callbackPath}`,\n      state,\n      'grant_options[]': isOnline ? 'per-user' : '',\n    };\n    const processedQuery = new ProcessedQuery();\n    processedQuery.putAll(query);\n\n    const redirectUrl = `https://${cleanShop}/admin/oauth/authorize${processedQuery.stringify()}`;\n    response.statusCode = 302;\n    response.statusText = 'Found';\n    response.headers = {\n      ...response.headers,\n      ...cookies.response.headers!,\n      Location: redirectUrl,\n    };\n\n    log.debug(`OAuth started, redirecting to ${redirectUrl}`, {shop, isOnline});\n\n    return abstractConvertResponse(response, adapterArgs);\n  };\n}"
+    }
+  },
+  "CallbackGeneratedType": {
+    "/auth/oauth/oauth.ts": {
+      "filePath": "/auth/oauth/oauth.ts",
+      "name": "CallbackGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/auth/oauth/oauth.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/oauth.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function callback(config: ConfigInterface) {\n  return async function callback<T = AdapterHeaders>({\n    isOnline: isOnlineParam,\n    ...adapterArgs\n  }: CallbackParams): Promise<CallbackResponse<T>> {\n    throwIfCustomStoreApp(\n      config.isCustomStoreApp,\n      'Cannot perform OAuth for private apps',\n    );\n\n    const log = logger(config);\n\n    if (isOnlineParam !== undefined) {\n      await log.deprecated(\n        '7.0.0',\n        'The isOnline param is no longer required for auth callback',\n      );\n    }\n\n    const request = await abstractConvertRequest(adapterArgs);\n\n    const query = new URL(\n      request.url,\n      `${config.hostScheme}://${config.hostName}`,\n    ).searchParams;\n    const shop = query.get('shop')!;\n\n    log.info('Completing OAuth', {shop});\n\n    const cookies = new Cookies(request, {} as NormalizedResponse, {\n      keys: [config.apiSecretKey],\n      secure: true,\n    });\n\n    const stateFromCookie = await cookies.getAndVerify(STATE_COOKIE_NAME);\n    cookies.deleteCookie(STATE_COOKIE_NAME);\n    if (!stateFromCookie) {\n      log.error('Could not find OAuth cookie', {shop});\n\n      throw new ShopifyErrors.CookieNotFound(\n        `Cannot complete OAuth process. Could not find an OAuth cookie for shop url: ${shop}`,\n      );\n    }\n\n    const authQuery: AuthQuery = Object.fromEntries(query.entries());\n    if (!(await validQuery({config, query: authQuery, stateFromCookie}))) {\n      log.error('Invalid OAuth callback', {shop, stateFromCookie});\n\n      throw new ShopifyErrors.InvalidOAuthError('Invalid OAuth callback.');\n    }\n\n    log.debug('OAuth request is valid, requesting access token', {shop});\n\n    const body = {\n      client_id: config.apiKey,\n      client_secret: config.apiSecretKey,\n      code: query.get('code'),\n    };\n\n    const postParams = {\n      path: '/admin/oauth/access_token',\n      type: DataType.JSON,\n      data: body,\n    };\n    const cleanShop = sanitizeShop(config)(query.get('shop')!, true)!;\n\n    const HttpClient = httpClientClass(config);\n    const client = new HttpClient({domain: cleanShop});\n    const postResponse = await client.post(postParams);\n\n    const session: Session = createSession({\n      postResponse,\n      shop: cleanShop,\n      stateFromCookie,\n      config,\n    });\n\n    if (!config.isEmbeddedApp) {\n      await cookies.setAndSign(SESSION_COOKIE_NAME, session.id, {\n        expires: session.expires,\n        sameSite: 'lax',\n        secure: true,\n        path: '/',\n      });\n    }\n\n    return {\n      headers: (await abstractConvertHeaders(\n        cookies.response.headers!,\n        adapterArgs,\n      )) as T,\n      session,\n    };\n  };\n}"
+    }
+  },
+  "ValidQueryGeneratedType": {
+    "/auth/oauth/oauth.ts": {
+      "filePath": "/auth/oauth/oauth.ts",
+      "name": "ValidQueryGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "{ config: ConfigInterface; query: AuthQuery; stateFromCookie: string; }",
+          "filePath": "/auth/oauth/oauth.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/oauth.ts",
+        "description": "",
+        "name": "Promise<boolean>",
+        "value": "Promise<boolean>"
+      },
+      "value": "async function validQuery({\n  config,\n  query,\n  stateFromCookie,\n}: {\n  config: ConfigInterface;\n  query: AuthQuery;\n  stateFromCookie: string;\n}): Promise<boolean> {\n  return (\n    (await validateHmac(config)(query)) &&\n    safeCompare(query.state!, stateFromCookie)\n  );\n}"
+    }
+  },
+  "CreateSessionGeneratedType": {
+    "/auth/oauth/oauth.ts": {
+      "filePath": "/auth/oauth/oauth.ts",
+      "name": "CreateSessionGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "{ config: ConfigInterface; postResponse: RequestReturn<unknown>; shop: string; stateFromCookie: string; }",
+          "filePath": "/auth/oauth/oauth.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/oauth.ts",
+        "description": "",
+        "name": "Session",
+        "value": "Session"
+      },
+      "value": "function createSession({\n  config,\n  postResponse,\n  shop,\n  stateFromCookie,\n}: {\n  config: ConfigInterface;\n  postResponse: RequestReturn;\n  shop: string;\n  stateFromCookie: string;\n}): Session {\n  const associatedUser = (postResponse.body as OnlineAccessResponse)\n    .associated_user;\n  const isOnline = Boolean(associatedUser);\n\n  logger(config).info('Creating new session', {shop, isOnline});\n\n  if (isOnline) {\n    let sessionId: string;\n    const responseBody = postResponse.body as OnlineAccessResponse;\n    const {access_token, scope, ...rest} = responseBody;\n    const sessionExpiration = new Date(\n      Date.now() + responseBody.expires_in * 1000,\n    );\n\n    if (config.isEmbeddedApp) {\n      sessionId = getJwtSessionId(config)(\n        shop,\n        `${(rest as OnlineAccessInfo).associated_user.id}`,\n      );\n    } else {\n      sessionId = uuidv4();\n    }\n\n    return new Session({\n      id: sessionId,\n      shop,\n      state: stateFromCookie,\n      isOnline,\n      accessToken: access_token,\n      scope,\n      expires: sessionExpiration,\n      onlineAccessInfo: rest,\n    });\n  } else {\n    const responseBody = postResponse.body as AccessTokenResponse;\n    return new Session({\n      id: getOfflineId(config)(shop),\n      shop,\n      state: stateFromCookie,\n      isOnline,\n      accessToken: responseBody.access_token,\n      scope: responseBody.scope,\n    });\n  }\n}"
+    }
+  },
+  "ThrowIfCustomStoreAppGeneratedType": {
+    "/auth/oauth/oauth.ts": {
+      "filePath": "/auth/oauth/oauth.ts",
+      "name": "ThrowIfCustomStoreAppGeneratedType",
+      "params": [
+        {
+          "name": "isCustomStoreApp",
+          "description": "",
+          "value": "boolean",
+          "filePath": "/auth/oauth/oauth.ts"
+        },
+        {
+          "name": "message",
+          "description": "",
+          "value": "string",
+          "filePath": "/auth/oauth/oauth.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/oauth.ts",
+        "description": "",
+        "name": "void",
+        "value": "void"
+      },
+      "value": "function throwIfCustomStoreApp(\n  isCustomStoreApp: boolean,\n  message: string,\n): void {\n  if (isCustomStoreApp) {\n    throw new ShopifyErrors.PrivateAppError(message);\n  }\n}"
+    }
+  },
+  "GetEmbeddedAppUrlParams": {
+    "/auth/types.ts": {
+      "filePath": "/auth/types.ts",
+      "name": "GetEmbeddedAppUrlParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "AdapterRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "/auth/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface GetEmbeddedAppUrlParams extends AdapterArgs {}"
+    }
+  },
+  "GetEmbeddedAppUrlGeneratedType": {
+    "/auth/get-embedded-app-url.ts": {
+      "filePath": "/auth/get-embedded-app-url.ts",
+      "name": "GetEmbeddedAppUrlGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/auth/get-embedded-app-url.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/get-embedded-app-url.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getEmbeddedAppUrl(config: ConfigInterface) {\n  return async ({...adapterArgs}: GetEmbeddedAppUrlParams): Promise<string> => {\n    const request = await abstractConvertRequest(adapterArgs);\n\n    if (!request) {\n      throw new ShopifyErrors.MissingRequiredArgument(\n        'getEmbeddedAppUrl requires a request object argument',\n      );\n    }\n\n    if (!request.url) {\n      throw new ShopifyErrors.InvalidRequestError(\n        'Request does not contain a URL',\n      );\n    }\n\n    const url = new URL(request.url, `https://${request.headers.host}`);\n    const host = url.searchParams.get('host');\n\n    if (typeof host !== 'string') {\n      throw new ShopifyErrors.InvalidRequestError(\n        'Request does not contain a host query parameter',\n      );\n    }\n\n    return buildEmbeddedAppUrl(config)(host);\n  };\n}"
+    }
+  },
+  "BuildEmbeddedAppUrlGeneratedType": {
+    "/auth/get-embedded-app-url.ts": {
+      "filePath": "/auth/get-embedded-app-url.ts",
+      "name": "BuildEmbeddedAppUrlGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/auth/get-embedded-app-url.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/get-embedded-app-url.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function buildEmbeddedAppUrl(config: ConfigInterface) {\n  return (host: string): string => {\n    sanitizeHost(config)(host, true);\n    const decodedHost = decodeHost(host);\n\n    return `https://${decodedHost}/apps/${config.apiKey}`;\n  };\n}"
+    }
+  },
+  "ShopifyAuthGeneratedType": {
+    "/auth/index.ts": {
+      "filePath": "/auth/index.ts",
+      "name": "ShopifyAuthGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/auth/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function shopifyAuth(config: ConfigInterface) {\n  return {\n    begin: begin(config),\n    callback: callback(config),\n    nonce,\n    safeCompare,\n    getEmbeddedAppUrl: getEmbeddedAppUrl(config),\n    buildEmbeddedAppUrl: buildEmbeddedAppUrl(config),\n  };\n}"
+    }
+  },
+  "ShopifyAuth": {
+    "/auth/index.ts": {
+      "filePath": "/auth/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyAuth",
+      "value": "ReturnType<typeof shopifyAuth>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/auth/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "begin",
+          "value": "({ shop, callbackPath, isOnline, ...adapterArgs }: BeginParams) => Promise<any>",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "callback",
+          "value": "<T = any>({ isOnline: isOnlineParam, ...adapterArgs }: CallbackParams) => Promise<CallbackResponse<T>>",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/index.ts",
+          "syntaxKind": "ShorthandPropertyAssignment",
+          "name": "nonce",
+          "value": "() => string",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/index.ts",
+          "syntaxKind": "ShorthandPropertyAssignment",
+          "name": "safeCompare",
+          "value": "(item1: SafeCompareParam, item2: SafeCompareParam) => boolean",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "getEmbeddedAppUrl",
+          "value": "({ ...adapterArgs }: GetEmbeddedAppUrlParams) => Promise<string>",
+          "description": ""
+        },
+        {
+          "filePath": "/auth/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "buildEmbeddedAppUrl",
+          "value": "(host: string) => string",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "ShopifySessionGeneratedType": {
+    "/session/index.ts": {
+      "filePath": "/session/index.ts",
+      "name": "ShopifySessionGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/session/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function shopifySession(config: ConfigInterface) {\n  return {\n    customAppSession: customAppSession(config),\n    getCurrentId: getCurrentSessionId(config),\n    getOfflineId: getOfflineId(config),\n    decodeSessionToken: decodeSessionToken(config),\n  };\n}"
+    }
+  },
+  "ShopifySession": {
+    "/session/index.ts": {
+      "filePath": "/session/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifySession",
+      "value": "ReturnType<typeof shopifySession>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/session/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "customAppSession",
+          "value": "(shop: string) => Session",
+          "description": ""
+        },
+        {
+          "filePath": "/session/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "getCurrentId",
+          "value": "({ isOnline, ...adapterArgs }: GetCurrentSessionIdParams) => Promise<string>",
+          "description": ""
+        },
+        {
+          "filePath": "/session/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "getOfflineId",
+          "value": "any",
+          "description": ""
+        },
+        {
+          "filePath": "/session/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "decodeSessionToken",
+          "value": "(token: string) => Promise<JwtPayload>",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "VersionCompatibileParams": {
+    "/utils/version-compatible.ts": {
+      "filePath": "/utils/version-compatible.ts",
+      "name": "VersionCompatibileParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/utils/version-compatible.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "referenceVersion",
+          "value": "ApiVersion",
+          "description": "The API version to check against."
+        }
+      ],
+      "value": "interface VersionCompatibileParams {\n  /** The API version to check against. */\n  referenceVersion: ApiVersion;\n}"
+    }
+  },
+  "VersionCompatibleReturns": {
+    "/utils/version-compatible.ts": {
+      "filePath": "/utils/version-compatible.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "VersionCompatibleReturns",
+      "value": "boolean",
+      "description": ""
+    }
+  },
+  "VersionCompatibleGeneratedType": {
+    "/utils/version-compatible.ts": {
+      "filePath": "/utils/version-compatible.ts",
+      "name": "VersionCompatibleGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/utils/version-compatible.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/version-compatible.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function versionCompatible(config: ConfigInterface) {\n  return (\n    referenceVersion: ApiVersion,\n    currentVersion: ApiVersion = config.apiVersion,\n  ): boolean => {\n    // Return true if not using a dated version\n    if (currentVersion === ApiVersion.Unstable) {\n      return true;\n    }\n    const numericVersion = (version: string) =>\n      parseInt(version.replace('-', ''), 10);\n    const current = numericVersion(currentVersion);\n    const reference = numericVersion(referenceVersion);\n    return current >= reference;\n  };\n}"
+    }
+  },
+  "ShopifyUtilsGeneratedType": {
+    "/utils/index.ts": {
+      "filePath": "/utils/index.ts",
+      "name": "ShopifyUtilsGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/utils/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/utils/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function shopifyUtils(config: ConfigInterface) {\n  return {\n    sanitizeShop: sanitizeShop(config),\n    sanitizeHost: sanitizeHost(config),\n    validateHmac: validateHmac(config),\n    versionCompatible: versionCompatible(config),\n  };\n}"
+    }
+  },
+  "ShopifyUtils": {
+    "/utils/index.ts": {
+      "filePath": "/utils/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyUtils",
+      "value": "ReturnType<typeof shopifyUtils>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/utils/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "sanitizeShop",
+          "value": "(shop: string, throwOnInvalid?: boolean) => string",
+          "description": ""
+        },
+        {
+          "filePath": "/utils/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "sanitizeHost",
+          "value": "(host: string, throwOnInvalid?: boolean) => string",
+          "description": ""
+        },
+        {
+          "filePath": "/utils/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "validateHmac",
+          "value": "(query: AuthQuery) => Promise<boolean>",
+          "description": ""
+        },
+        {
+          "filePath": "/utils/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "versionCompatible",
+          "value": "(referenceVersion: ApiVersion, currentVersion?: ApiVersion) => boolean",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "DeliveryMethod": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "DeliveryMethod",
+      "value": "export enum DeliveryMethod {\n  Http = 'http',\n  EventBridge = 'eventbridge',\n  PubSub = 'pubsub',\n}",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "Http",
+          "value": "http"
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "EventBridge",
+          "value": "eventbridge"
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "PubSub",
+          "value": "pubsub"
+        }
+      ]
+    }
+  },
+  "WebhookHandlerFunction": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "WebhookHandlerFunction",
+      "value": "(\n  topic: string,\n  shop_domain: string,\n  body: string,\n  webhookId: string,\n  apiVersion?: string,\n) => Promise<void>",
+      "description": ""
+    }
+  },
+  "BaseWebhookHandler": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "BaseWebhookHandler",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "includeFields",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafieldNamespaces",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface BaseWebhookHandler {\n  id?: string;\n  includeFields?: string[];\n  metafieldNamespaces?: string[];\n}"
+    }
+  },
+  "HttpWebhookHandler": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "HttpWebhookHandler",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryMethod",
+          "value": "DeliveryMethod.Http",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "privateMetafieldNamespaces",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "callbackUrl",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "callback",
+          "value": "WebhookHandlerFunction",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "includeFields",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafieldNamespaces",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface HttpWebhookHandler extends BaseWebhookHandler {\n  deliveryMethod: DeliveryMethod.Http;\n  privateMetafieldNamespaces?: string[];\n  callbackUrl: string;\n  callback: WebhookHandlerFunction;\n}"
+    }
+  },
+  "EventBridgeWebhookHandler": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "EventBridgeWebhookHandler",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryMethod",
+          "value": "DeliveryMethod.EventBridge",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "arn",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "includeFields",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafieldNamespaces",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface EventBridgeWebhookHandler extends BaseWebhookHandler {\n  deliveryMethod: DeliveryMethod.EventBridge;\n  arn: string;\n}"
+    }
+  },
+  "PubSubWebhookHandler": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "PubSubWebhookHandler",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryMethod",
+          "value": "DeliveryMethod.PubSub",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "pubSubProject",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "pubSubTopic",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "includeFields",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "metafieldNamespaces",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface PubSubWebhookHandler extends BaseWebhookHandler {\n  deliveryMethod: DeliveryMethod.PubSub;\n  pubSubProject: string;\n  pubSubTopic: string;\n}"
+    }
+  },
+  "WebhookHandler": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "WebhookHandler",
+      "value": "HttpWebhookHandler | EventBridgeWebhookHandler | PubSubWebhookHandler",
+      "description": ""
+    }
+  },
+  "WebhookRegistry": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "WebhookRegistry",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "[topic: string]",
+          "value": "WebhookHandler[]"
+        }
+      ],
+      "value": "export interface WebhookRegistry {\n  // See https://shopify.dev/docs/api/admin-graphql/latest/enums/webhooksubscriptiontopic for available topics\n  [topic: string]: WebhookHandler[];\n}"
+    }
+  },
+  "WebhookOperation": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "WebhookOperation",
+      "value": "export enum WebhookOperation {\n  Create = 'create',\n  Update = 'update',\n  Delete = 'delete',\n}",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "Create",
+          "value": "create"
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "Update",
+          "value": "update"
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "Delete",
+          "value": "delete"
+        }
+      ]
+    }
+  },
+  "RegisterParams": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "RegisterParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        }
+      ],
+      "value": "export interface RegisterParams {\n  session: Session;\n}"
+    }
+  },
+  "RegisterResult": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "RegisterResult",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "success",
+          "value": "boolean",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "deliveryMethod",
+          "value": "DeliveryMethod",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "result",
+          "value": "unknown",
+          "description": ""
+        }
+      ],
+      "value": "export interface RegisterResult {\n  success: boolean;\n  deliveryMethod: DeliveryMethod;\n  result: unknown;\n}"
+    }
+  },
+  "RegisterReturn": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "RegisterReturn",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "[topic: string]",
+          "value": "RegisterResult[]"
+        }
+      ],
+      "value": "export interface RegisterReturn {\n  [topic: string]: RegisterResult[];\n}"
+    }
+  },
+  "WebhookCheckResponseNode": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "WebhookCheckResponseNode",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "node",
+          "value": "{ id: string; topic: string; includeFields: string[]; metafieldNamespaces: string[]; privateMetafieldNamespaces: string[]; } & T",
+          "description": ""
+        }
+      ],
+      "value": "export interface WebhookCheckResponseNode<\n  T = {\n    endpoint:\n      | {\n          __typename: 'WebhookHttpEndpoint';\n          callbackUrl: string;\n        }\n      | {\n          __typename: 'WebhookEventBridgeEndpoint';\n          arn: string;\n        }\n      | {\n          __typename: 'WebhookPubSubEndpoint';\n          pubSubProject: string;\n          pubSubTopic: string;\n        };\n  },\n> {\n  node: {\n    id: string;\n    topic: string;\n    includeFields: string[];\n    metafieldNamespaces: string[];\n    privateMetafieldNamespaces: string[];\n  } & T;\n}"
+    }
+  },
+  "WebhookCheckResponse": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "WebhookCheckResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "{ webhookSubscriptions: { edges: T[]; pageInfo: { endCursor: string; hasNextPage: boolean; }; }; }",
+          "description": ""
+        }
+      ],
+      "value": "export interface WebhookCheckResponse<T = WebhookCheckResponseNode> {\n  data: {\n    webhookSubscriptions: {\n      edges: T[];\n      pageInfo: {\n        endCursor: string;\n        hasNextPage: boolean;\n      };\n    };\n  };\n}"
+    }
+  },
+  "AddHandlersParams": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "AddHandlersParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "name": "[topic: string]",
+          "value": "WebhookHandler | WebhookHandler[]"
+        }
+      ],
+      "value": "export interface AddHandlersParams {\n  [topic: string]: WebhookHandler | WebhookHandler[];\n}"
+    }
+  },
+  "WebhookProcessParams": {
+    "/webhooks/types.ts": {
+      "filePath": "/webhooks/types.ts",
+      "name": "WebhookProcessParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawBody",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "AdapterRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface WebhookProcessParams extends AdapterArgs {\n  rawBody: string;\n}"
+    }
+  },
+  "RegistryGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "RegistryGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "WebhookRegistry",
+        "value": "WebhookRegistry"
+      },
+      "value": "export function registry(): WebhookRegistry {\n  return {};\n}"
+    }
+  },
+  "TopicForStorageGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "TopicForStorageGeneratedType",
+      "params": [
+        {
+          "name": "topic",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function topicForStorage(topic: string): string {\n  return topic.toUpperCase().replace(/\\//g, '_');\n}"
+    }
+  },
+  "AddHandlersGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "AddHandlersGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/registry.ts"
+        },
+        {
+          "name": "webhookRegistry",
+          "description": "",
+          "value": "WebhookRegistry",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function addHandlers(\n  config: ConfigInterface,\n  webhookRegistry: WebhookRegistry,\n) {\n  return async function addHandlers(handlersToAdd: AddHandlersParams) {\n    for (const [topic, handlers] of Object.entries(handlersToAdd)) {\n      const topicKey = topicForStorage(topic);\n\n      if (Array.isArray(handlers)) {\n        for (const handler of handlers) {\n          await mergeOrAddHandler(config, webhookRegistry, topicKey, handler);\n        }\n      } else {\n        await mergeOrAddHandler(config, webhookRegistry, topicKey, handlers);\n      }\n    }\n  };\n}"
+    }
+  },
+  "GetTopicsAddedGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "GetTopicsAddedGeneratedType",
+      "params": [
+        {
+          "name": "webhookRegistry",
+          "description": "",
+          "value": "WebhookRegistry",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getTopicsAdded(webhookRegistry: WebhookRegistry) {\n  return function getTopicsAdded(): string[] {\n    return Object.keys(webhookRegistry);\n  };\n}"
+    }
+  },
+  "GetHandlersGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "GetHandlersGeneratedType",
+      "params": [
+        {
+          "name": "webhookRegistry",
+          "description": "",
+          "value": "WebhookRegistry",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getHandlers(webhookRegistry: WebhookRegistry) {\n  return function getHandlers(topic: string): WebhookHandler[] {\n    return webhookRegistry[topicForStorage(topic)] || [];\n  };\n}"
+    }
+  },
+  "HandlerIdentifierGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "HandlerIdentifierGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/registry.ts"
+        },
+        {
+          "name": "handler",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function handlerIdentifier(\n  config: ConfigInterface,\n  handler: WebhookHandler,\n): string {\n  const prefix = handler.deliveryMethod;\n\n  switch (handler.deliveryMethod) {\n    case DeliveryMethod.Http:\n      return `${prefix}_${addHostToCallbackUrl(config, handler.callbackUrl)}`;\n    case DeliveryMethod.EventBridge:\n      return `${prefix}_${handler.arn}`;\n    case DeliveryMethod.PubSub:\n      return `${prefix}_${handler.pubSubProject}:${handler.pubSubTopic}`;\n    default:\n      throw new InvalidDeliveryMethodError(\n        `Unrecognized delivery method '${(handler as any).deliveryMethod}'`,\n      );\n  }\n}"
+    }
+  },
+  "AddHostToCallbackUrlGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "AddHostToCallbackUrlGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/registry.ts"
+        },
+        {
+          "name": "callbackUrl",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function addHostToCallbackUrl(\n  config: ConfigInterface,\n  callbackUrl: string,\n): string {\n  if (callbackUrl.startsWith('/')) {\n    return `${config.hostScheme}://${config.hostName}${callbackUrl}`;\n  } else {\n    return callbackUrl;\n  }\n}"
+    }
+  },
+  "MergeOrAddHandlerGeneratedType": {
+    "/webhooks/registry.ts": {
+      "filePath": "/webhooks/registry.ts",
+      "name": "MergeOrAddHandlerGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/registry.ts"
+        },
+        {
+          "name": "webhookRegistry",
+          "description": "",
+          "value": "WebhookRegistry",
+          "filePath": "/webhooks/registry.ts"
+        },
+        {
+          "name": "topic",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/registry.ts"
+        },
+        {
+          "name": "handler",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/registry.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/registry.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "async function mergeOrAddHandler(\n  config: ConfigInterface,\n  webhookRegistry: WebhookRegistry,\n  topic: string,\n  handler: WebhookHandler,\n) {\n  handler.includeFields?.sort();\n  handler.metafieldNamespaces?.sort();\n  if (handler.deliveryMethod === DeliveryMethod.Http) {\n    handler.privateMetafieldNamespaces?.sort();\n  }\n\n  if (!(topic in webhookRegistry)) {\n    webhookRegistry[topic] = [handler];\n    return;\n  }\n\n  const identifier = handlerIdentifier(config, handler);\n\n  for (const index in webhookRegistry[topic]) {\n    if (!Object.prototype.hasOwnProperty.call(webhookRegistry[topic], index)) {\n      continue;\n    }\n\n    const existingHandler = webhookRegistry[topic][index];\n    const existingIdentifier = handlerIdentifier(config, existingHandler);\n\n    if (identifier !== existingIdentifier) {\n      continue;\n    }\n\n    if (handler.deliveryMethod === DeliveryMethod.Http) {\n      await logger(config).info(\n        `Detected multiple handlers for '${topic}', webhooks.process will call them sequentially`,\n      );\n      break;\n    } else {\n      throw new InvalidDeliveryMethodError(\n        `Can only add multiple handlers when deliveryMethod is Http. Invalid handler: ${JSON.stringify(\n          handler,\n        )}`,\n      );\n    }\n  }\n\n  webhookRegistry[topic].push(handler);\n}"
+    }
+  },
+  "QueryTemplateGeneratedType": {
+    "/webhooks/query-template.ts": {
+      "filePath": "/webhooks/query-template.ts",
+      "name": "QueryTemplateGeneratedType",
+      "params": [
+        {
+          "name": "template",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/query-template.ts"
+        },
+        {
+          "name": "params",
+          "description": "",
+          "value": "{ [key: string]: any; }",
+          "filePath": "/webhooks/query-template.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/query-template.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function queryTemplate(template: string, params: {[key: string]: any}) {\n  let query = template;\n\n  Object.entries(params).forEach(([key, value]) => {\n    query = query.replace(`{{${key}}}`, value);\n  });\n\n  return query;\n}"
+    }
+  },
+  "RegisterTopicParams": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RegisterTopicParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "topic",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "existingHandlers",
+          "value": "WebhookHandler[]",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handlers",
+          "value": "WebhookHandler[]",
+          "description": ""
+        }
+      ],
+      "value": "interface RegisterTopicParams {\n  config: ConfigInterface;\n  session: Session;\n  topic: string;\n  existingHandlers: WebhookHandler[];\n  handlers: WebhookHandler[];\n}"
+    }
+  },
+  "RunMutationsParams": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RunMutationsParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "topic",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handlers",
+          "value": "WebhookHandler[]",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "operation",
+          "value": "WebhookOperation",
+          "description": ""
+        }
+      ],
+      "value": "interface RunMutationsParams {\n  config: ConfigInterface;\n  client: GraphqlClient;\n  topic: string;\n  handlers: WebhookHandler[];\n  operation: WebhookOperation;\n}"
+    }
+  },
+  "RunMutationParams": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RunMutationParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "topic",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "handler",
+          "value": "WebhookHandler",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/register.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "operation",
+          "value": "WebhookOperation",
+          "description": ""
+        }
+      ],
+      "value": "interface RunMutationParams {\n  config: ConfigInterface;\n  client: GraphqlClient;\n  topic: string;\n  handler: WebhookHandler;\n  operation: WebhookOperation;\n}"
+    }
+  },
+  "RegisterGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RegisterGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "webhookRegistry",
+          "description": "",
+          "value": "WebhookRegistry",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function register(\n  config: ConfigInterface,\n  webhookRegistry: WebhookRegistry,\n) {\n  return async function register({\n    session,\n  }: RegisterParams): Promise<RegisterReturn> {\n    const log = logger(config);\n    log.info('Registering webhooks', {shop: session.shop});\n\n    const registerReturn: RegisterReturn = Object.keys(webhookRegistry).reduce(\n      (acc: RegisterReturn, topic) => {\n        acc[topic] = [];\n        return acc;\n      },\n      {},\n    );\n\n    const existingHandlers = await getExistingHandlers(config, session);\n\n    log.debug(\n      `Existing topics: [${Object.keys(existingHandlers).join(', ')}]`,\n      {shop: session.shop},\n    );\n\n    for (const topic in webhookRegistry) {\n      if (!Object.prototype.hasOwnProperty.call(webhookRegistry, topic)) {\n        continue;\n      }\n\n      if (gdprTopics.includes(topic)) {\n        continue;\n      }\n\n      registerReturn[topic] = await registerTopic({\n        config,\n        session,\n        topic,\n        existingHandlers: existingHandlers[topic] || [],\n        handlers: getHandlers(webhookRegistry)(topic),\n      });\n\n      // Remove this topic from the list of existing handlers so we have a list of leftovers\n      delete existingHandlers[topic];\n    }\n\n    // Delete any leftover handlers\n    for (const topic in existingHandlers) {\n      if (!Object.prototype.hasOwnProperty.call(existingHandlers, topic)) {\n        continue;\n      }\n\n      const GraphqlClient = graphqlClientClass({config});\n      const client = new GraphqlClient({session});\n\n      registerReturn[topic] = await runMutations({\n        config,\n        client,\n        topic,\n        handlers: existingHandlers[topic],\n        operation: WebhookOperation.Delete,\n      });\n    }\n\n    return registerReturn;\n  };\n}"
+    }
+  },
+  "GetExistingHandlersGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "GetExistingHandlersGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "session",
+          "description": "",
+          "value": "Session",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "Promise<WebhookRegistry>",
+        "value": "Promise<WebhookRegistry>"
+      },
+      "value": "async function getExistingHandlers(\n  config: ConfigInterface,\n  session: Session,\n): Promise<WebhookRegistry> {\n  const GraphqlClient = graphqlClientClass({config});\n  const client = new GraphqlClient({session});\n\n  const existingHandlers: WebhookRegistry = {};\n\n  let hasNextPage: boolean;\n  let endCursor: string | null = null;\n  do {\n    const query = buildCheckQuery(endCursor);\n\n    const response = await client.query<WebhookCheckResponse>({\n      data: query,\n    });\n\n    response.body.data.webhookSubscriptions.edges.forEach((edge) => {\n      const handler = buildHandlerFromNode(edge);\n\n      if (!existingHandlers[edge.node.topic]) {\n        existingHandlers[edge.node.topic] = [];\n      }\n\n      existingHandlers[edge.node.topic].push(handler);\n    });\n\n    endCursor = response.body.data.webhookSubscriptions.pageInfo.endCursor;\n    hasNextPage = response.body.data.webhookSubscriptions.pageInfo.hasNextPage;\n  } while (hasNextPage);\n\n  return existingHandlers;\n}"
+    }
+  },
+  "BuildCheckQueryGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "BuildCheckQueryGeneratedType",
+      "params": [
+        {
+          "name": "endCursor",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "function buildCheckQuery(endCursor: string | null) {\n  return queryTemplate(TEMPLATE_GET_HANDLERS, {\n    END_CURSOR: JSON.stringify(endCursor),\n  });\n}"
+    }
+  },
+  "BuildHandlerFromNodeGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "BuildHandlerFromNodeGeneratedType",
+      "params": [
+        {
+          "name": "edge",
+          "description": "",
+          "value": "WebhookCheckResponseNode<{ endpoint: { __typename: \"WebhookHttpEndpoint\"; callbackUrl: string; } | { __typename: \"WebhookEventBridgeEndpoint\"; arn: string; } | { __typename: \"WebhookPubSubEndpoint\"; pubSubProject: string; pubSubTopic: string; }; }>",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "WebhookHandler",
+        "value": "WebhookHandler"
+      },
+      "value": "function buildHandlerFromNode(edge: WebhookCheckResponseNode): WebhookHandler {\n  const endpoint = edge.node.endpoint;\n\n  let handler: WebhookHandler;\n\n  switch (endpoint.__typename) {\n    case 'WebhookHttpEndpoint':\n      handler = {\n        deliveryMethod: DeliveryMethod.Http,\n        privateMetafieldNamespaces: edge.node.privateMetafieldNamespaces,\n        callbackUrl: endpoint.callbackUrl,\n        // This is a dummy for now because we don't really care about it\n        callback: async () => {},\n      };\n\n      // This field only applies to HTTP webhooks\n      handler.privateMetafieldNamespaces?.sort();\n      break;\n    case 'WebhookEventBridgeEndpoint':\n      handler = {\n        deliveryMethod: DeliveryMethod.EventBridge,\n        arn: endpoint.arn,\n      };\n      break;\n    case 'WebhookPubSubEndpoint':\n      handler = {\n        deliveryMethod: DeliveryMethod.PubSub,\n        pubSubProject: endpoint.pubSubProject,\n        pubSubTopic: endpoint.pubSubTopic,\n      };\n      break;\n  }\n\n  // Set common fields\n  handler.id = edge.node.id;\n  handler.includeFields = edge.node.includeFields;\n  handler.metafieldNamespaces = edge.node.metafieldNamespaces;\n\n  // Sort the array fields to make them cheaper to compare later on\n  handler.includeFields?.sort();\n  handler.metafieldNamespaces?.sort();\n\n  return handler;\n}"
+    }
+  },
+  "RegisterTopicGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RegisterTopicGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "RegisterTopicParams",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "Promise<RegisterResult[]>",
+        "value": "Promise<RegisterResult[]>"
+      },
+      "value": "async function registerTopic({\n  config,\n  session,\n  topic,\n  existingHandlers,\n  handlers,\n}: RegisterTopicParams): Promise<RegisterResult[]> {\n  let registerResults: RegisterResult[] = [];\n\n  const {toCreate, toUpdate, toDelete} = categorizeHandlers(\n    config,\n    existingHandlers,\n    handlers,\n  );\n\n  const GraphqlClient = graphqlClientClass({config});\n  const client = new GraphqlClient({session});\n\n  let operation = WebhookOperation.Create;\n  registerResults = registerResults.concat(\n    await runMutations({config, client, topic, operation, handlers: toCreate}),\n  );\n\n  operation = WebhookOperation.Update;\n  registerResults = registerResults.concat(\n    await runMutations({config, client, topic, operation, handlers: toUpdate}),\n  );\n\n  operation = WebhookOperation.Delete;\n  registerResults = registerResults.concat(\n    await runMutations({config, client, topic, operation, handlers: toDelete}),\n  );\n\n  return registerResults;\n}"
+    }
+  },
+  "HandlersByKey": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "HandlersByKey",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/register.ts",
+          "name": "[key: string]",
+          "value": "WebhookHandler"
+        }
+      ],
+      "value": "interface HandlersByKey {\n  [key: string]: WebhookHandler;\n}"
+    }
+  },
+  "CategorizeHandlersGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "CategorizeHandlersGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "existingHandlers",
+          "description": "",
+          "value": "WebhookHandler[]",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "handlers",
+          "description": "",
+          "value": "WebhookHandler[]",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "function categorizeHandlers(\n  config: ConfigInterface,\n  existingHandlers: WebhookHandler[],\n  handlers: WebhookHandler[],\n) {\n  const handlersByKey = handlers.reduce((acc: HandlersByKey, value) => {\n    acc[handlerIdentifier(config, value)] = value;\n    return acc;\n  }, {});\n  const existingHandlersByKey = existingHandlers.reduce(\n    (acc: HandlersByKey, value) => {\n      acc[handlerIdentifier(config, value)] = value;\n      return acc;\n    },\n    {},\n  );\n\n  const toCreate: HandlersByKey = {...handlersByKey};\n  const toUpdate: HandlersByKey = {};\n  const toDelete: HandlersByKey = {};\n  for (const existingKey in existingHandlersByKey) {\n    if (\n      !Object.prototype.hasOwnProperty.call(existingHandlersByKey, existingKey)\n    ) {\n      continue;\n    }\n\n    const existingHandler = existingHandlersByKey[existingKey];\n    const handler = handlersByKey[existingKey];\n\n    if (existingKey in handlersByKey) {\n      delete toCreate[existingKey];\n\n      if (!areHandlerFieldsEqual(existingHandler, handler)) {\n        toUpdate[existingKey] = handler;\n        toUpdate[existingKey].id = existingHandler.id;\n      }\n    } else {\n      toDelete[existingKey] = existingHandler;\n    }\n  }\n\n  return {\n    toCreate: Object.values(toCreate),\n    toUpdate: Object.values(toUpdate),\n    toDelete: Object.values(toDelete),\n  };\n}"
+    }
+  },
+  "AreHandlerFieldsEqualGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "AreHandlerFieldsEqualGeneratedType",
+      "params": [
+        {
+          "name": "arr1",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "arr2",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "function areHandlerFieldsEqual(\n  arr1: WebhookHandler,\n  arr2: WebhookHandler,\n): boolean {\n  const includeFieldsEqual = arraysEqual(\n    arr1.includeFields || [],\n    arr2.includeFields || [],\n  );\n  const metafieldNamespacesEqual = arraysEqual(\n    arr1.metafieldNamespaces || [],\n    arr2.metafieldNamespaces || [],\n  );\n  const privateMetafieldNamespacesEqual =\n    arr1.deliveryMethod !== DeliveryMethod.Http ||\n    arr2.deliveryMethod !== DeliveryMethod.Http ||\n    arraysEqual(\n      arr1.privateMetafieldNamespaces || [],\n      arr2.privateMetafieldNamespaces || [],\n    );\n\n  return (\n    includeFieldsEqual &&\n    metafieldNamespacesEqual &&\n    privateMetafieldNamespacesEqual\n  );\n}"
+    }
+  },
+  "ArraysEqualGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "ArraysEqualGeneratedType",
+      "params": [
+        {
+          "name": "arr1",
+          "description": "",
+          "value": "any[]",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "arr2",
+          "description": "",
+          "value": "any[]",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "function arraysEqual(arr1: any[], arr2: any[]): boolean {\n  if (arr1.length !== arr2.length) {\n    return false;\n  }\n\n  for (let i = 0; i < arr1.length; i++) {\n    if (arr1[i] !== arr2[i]) {\n      return false;\n    }\n  }\n\n  return true;\n}"
+    }
+  },
+  "RunMutationsGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RunMutationsGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "RunMutationsParams",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "Promise<RegisterResult[]>",
+        "value": "Promise<RegisterResult[]>"
+      },
+      "value": "async function runMutations({\n  config,\n  client,\n  topic,\n  handlers,\n  operation,\n}: RunMutationsParams): Promise<RegisterResult[]> {\n  const registerResults: RegisterResult[] = [];\n\n  for (const handler of handlers) {\n    registerResults.push(\n      await runMutation({config, client, topic, handler, operation}),\n    );\n  }\n\n  return registerResults;\n}"
+    }
+  },
+  "RunMutationGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "RunMutationGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "RunMutationParams",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "Promise<RegisterResult>",
+        "value": "Promise<RegisterResult>"
+      },
+      "value": "async function runMutation({\n  config,\n  client,\n  topic,\n  handler,\n  operation,\n}: RunMutationParams): Promise<RegisterResult> {\n  let registerResult: RegisterResult;\n\n  logger(config).debug(`Running webhook mutation`, {topic, operation});\n\n  try {\n    const query = buildMutation(config, topic, handler, operation);\n\n    const result = await client.query({data: query});\n\n    registerResult = {\n      deliveryMethod: handler.deliveryMethod,\n      success: isSuccess(result.body, handler, operation),\n      result: result.body,\n    };\n  } catch (error) {\n    if (error instanceof InvalidDeliveryMethodError) {\n      registerResult = {\n        deliveryMethod: handler.deliveryMethod,\n        success: false,\n        result: {message: error.message},\n      };\n    } else {\n      throw error;\n    }\n  }\n\n  return registerResult;\n}"
+    }
+  },
+  "BuildMutationGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "BuildMutationGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "topic",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "handler",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "operation",
+          "description": "",
+          "value": "WebhookOperation",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "function buildMutation(\n  config: ConfigInterface,\n  topic: string,\n  handler: WebhookHandler,\n  operation: WebhookOperation,\n): string {\n  const params: {[key: string]: string} = {};\n\n  let identifier: string;\n  if (handler.id) {\n    identifier = `id: \"${handler.id}\"`;\n  } else {\n    identifier = `topic: ${topic}`;\n  }\n\n  const mutationArguments = {\n    MUTATION_NAME: getMutationName(handler, operation),\n    IDENTIFIER: identifier,\n    MUTATION_PARAMS: '',\n  };\n\n  if (operation !== WebhookOperation.Delete) {\n    switch (handler.deliveryMethod) {\n      case DeliveryMethod.Http:\n        params.callbackUrl = `\"${addHostToCallbackUrl(\n          config,\n          handler.callbackUrl,\n        )}\"`;\n        break;\n      case DeliveryMethod.EventBridge:\n        params.arn = `\"${handler.arn}\"`;\n        break;\n      case DeliveryMethod.PubSub:\n        params.pubSubProject = `\"${handler.pubSubProject}\"`;\n        params.pubSubTopic = `\"${handler.pubSubTopic}\"`;\n        break;\n      default:\n        throw new InvalidDeliveryMethodError(\n          `Unrecognized delivery method '${(handler as any).deliveryMethod}'`,\n        );\n    }\n\n    if (handler.includeFields) {\n      params.includeFields = JSON.stringify(handler.includeFields);\n    }\n    if (handler.metafieldNamespaces) {\n      params.metafieldNamespaces = JSON.stringify(handler.metafieldNamespaces);\n    }\n    if (\n      handler.deliveryMethod === DeliveryMethod.Http &&\n      handler.privateMetafieldNamespaces\n    ) {\n      params.privateMetafieldNamespaces = JSON.stringify(\n        handler.privateMetafieldNamespaces,\n      );\n    }\n\n    const paramsString = Object.entries(params)\n      .map(([key, value]) => `${key}: ${value}`)\n      .join(', ');\n\n    mutationArguments.MUTATION_PARAMS = `webhookSubscription: {${paramsString}}`;\n  }\n\n  return queryTemplate(TEMPLATE_MUTATION, mutationArguments);\n}"
+    }
+  },
+  "GetMutationNameGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "GetMutationNameGeneratedType",
+      "params": [
+        {
+          "name": "handler",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "operation",
+          "description": "",
+          "value": "WebhookOperation",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "function getMutationName(\n  handler: WebhookHandler,\n  operation: WebhookOperation,\n): string {\n  switch (operation) {\n    case WebhookOperation.Create:\n      return `${getEndpoint(handler)}Create`;\n    case WebhookOperation.Update:\n      return `${getEndpoint(handler)}Update`;\n    case WebhookOperation.Delete:\n      return 'webhookSubscriptionDelete';\n    default:\n      throw new ShopifyError(`Unrecognized operation '${operation}'`);\n  }\n}"
+    }
+  },
+  "GetEndpointGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "GetEndpointGeneratedType",
+      "params": [
+        {
+          "name": "handler",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "function getEndpoint(handler: WebhookHandler): string {\n  switch (handler.deliveryMethod) {\n    case DeliveryMethod.Http:\n      return 'webhookSubscription';\n    case DeliveryMethod.EventBridge:\n      return 'eventBridgeWebhookSubscription';\n    case DeliveryMethod.PubSub:\n      return 'pubSubWebhookSubscription';\n    default:\n      throw new ShopifyError(\n        `Unrecognized delivery method '${(handler as any).deliveryMethod}'`,\n      );\n  }\n}"
+    }
+  },
+  "IsSuccessGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "IsSuccessGeneratedType",
+      "params": [
+        {
+          "name": "result",
+          "description": "",
+          "value": "any",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "handler",
+          "description": "",
+          "value": "WebhookHandler",
+          "filePath": "/webhooks/register.ts"
+        },
+        {
+          "name": "operation",
+          "description": "",
+          "value": "WebhookOperation",
+          "filePath": "/webhooks/register.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/register.ts",
+        "description": "",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "function isSuccess(\n  result: any,\n  handler: WebhookHandler,\n  operation: WebhookOperation,\n): boolean {\n  const mutationName = getMutationName(handler, operation);\n\n  return Boolean(\n    result.data &&\n      result.data[mutationName] &&\n      result.data[mutationName].userErrors.length === 0,\n  );\n}"
+    }
+  },
+  "TEMPLATE_GET_HANDLERSGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "TEMPLATE_GET_HANDLERSGeneratedType",
+      "value": "TEMPLATE_GET_HANDLERS = `{\n  webhookSubscriptions(\n    first: 250,\n    after: {{END_CURSOR}},\n  ) {\n    edges {\n      node {\n        id\n        topic\n        includeFields\n        metafieldNamespaces\n        privateMetafieldNamespaces\n        endpoint {\n          __typename\n          ... on WebhookHttpEndpoint {\n            callbackUrl\n          }\n          ... on WebhookEventBridgeEndpoint {\n            arn\n          }\n          ... on WebhookPubSubEndpoint {\n            pubSubProject\n            pubSubTopic\n          }\n        }\n      }\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}`"
+    }
+  },
+  "TEMPLATE_MUTATIONGeneratedType": {
+    "/webhooks/register.ts": {
+      "filePath": "/webhooks/register.ts",
+      "name": "TEMPLATE_MUTATIONGeneratedType",
+      "value": "TEMPLATE_MUTATION = `\n  mutation webhookSubscription {\n    {{MUTATION_NAME}}(\n      {{IDENTIFIER}},\n      {{MUTATION_PARAMS}}\n    ) {\n      userErrors {\n        field\n        message\n      }\n    }\n  }\n`"
+    }
+  },
+  "ProcessGeneratedType": {
+    "/webhooks/process.ts": {
+      "filePath": "/webhooks/process.ts",
+      "name": "ProcessGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/process.ts"
+        },
+        {
+          "name": "webhookRegistry",
+          "description": "",
+          "value": "WebhookRegistry",
+          "filePath": "/webhooks/process.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/process.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function process(\n  config: ConfigInterface,\n  webhookRegistry: WebhookRegistry,\n) {\n  return async function process({\n    rawBody,\n    ...adapterArgs\n  }: WebhookProcessParams): Promise<AdapterResponse> {\n    const request: NormalizedRequest = await abstractConvertRequest(\n      adapterArgs,\n    );\n    const response: NormalizedResponse = {\n      statusCode: StatusCode.Ok,\n      statusText: statusTextLookup[StatusCode.Ok],\n      headers: {},\n    };\n\n    const webhookCheck = checkWebhookRequest(rawBody, request.headers);\n    const {webhookOk, apiVersion, domain, hmac, topic, webhookId} =\n      webhookCheck;\n    let {errorMessage} = webhookCheck;\n    const loggingContext = {apiVersion, domain, topic, webhookId};\n\n    const log = logger(config);\n    log.info('Processing webhook request', loggingContext);\n\n    if (webhookOk) {\n      log.debug('Webhook request is well formed', loggingContext);\n\n      if (await validateOkWebhook(config.apiSecretKey, rawBody, hmac)) {\n        log.debug('Webhook request is valid', loggingContext);\n\n        const graphqlTopic = topicForStorage(topic);\n        const handlers = webhookRegistry[graphqlTopic] || [];\n\n        let found = false;\n        for (const handler of handlers) {\n          if (handler.deliveryMethod !== DeliveryMethod.Http) {\n            continue;\n          }\n          found = true;\n\n          log.debug('Found HTTP handler, triggering it', loggingContext);\n\n          try {\n            await handler.callback(\n              graphqlTopic,\n              domain,\n              rawBody,\n              webhookId,\n              apiVersion,\n            );\n            response.statusCode = StatusCode.Ok;\n          } catch (error) {\n            response.statusCode = StatusCode.InternalServerError;\n            errorMessage = error.message;\n          }\n        }\n\n        if (!found) {\n          log.debug('No HTTP handlers found', loggingContext);\n\n          response.statusCode = StatusCode.NotFound;\n          errorMessage = `No HTTP webhooks registered for topic ${graphqlTopic}`;\n        }\n      } else {\n        log.debug('Webhook validation failed', loggingContext);\n\n        response.statusCode = StatusCode.Unauthorized;\n        errorMessage = `Could not validate request for topic ${topic}`;\n      }\n    } else {\n      log.debug('Webhook request is malformed', loggingContext);\n\n      response.statusCode = StatusCode.BadRequest;\n    }\n\n    response.statusText = statusTextLookup[response.statusCode];\n    const returnResponse = await abstractConvertResponse(response, adapterArgs);\n    if (!isOK(response)) {\n      throw new ShopifyErrors.InvalidWebhookError({\n        message: errorMessage,\n        response: returnResponse,\n      });\n    }\n\n    return Promise.resolve(returnResponse);\n  };\n}"
+    }
+  },
+  "StatusTextLookupGeneratedType": {
+    "/webhooks/process.ts": {
+      "filePath": "/webhooks/process.ts",
+      "name": "StatusTextLookupGeneratedType",
+      "value": "statusTextLookup: {[key: string]: string} = {\n  [StatusCode.Ok]: 'OK',\n  [StatusCode.BadRequest]: 'Bad Request',\n  [StatusCode.Unauthorized]: 'Unauthorized',\n  [StatusCode.NotFound]: 'Not Found',\n  [StatusCode.InternalServerError]: 'Internal Server Error',\n}"
+    }
+  },
+  "HeaderPropertiesGeneratedType": {
+    "/webhooks/process.ts": {
+      "filePath": "/webhooks/process.ts",
+      "name": "HeaderPropertiesGeneratedType",
+      "value": "headerProperties: {property: string; headerName: ShopifyHeader}[] = [\n  {\n    property: 'apiVersion',\n    headerName: ShopifyHeader.ApiVersion,\n  },\n  {\n    property: 'domain',\n    headerName: ShopifyHeader.Domain,\n  },\n  {\n    property: 'hmac',\n    headerName: ShopifyHeader.Hmac,\n  },\n  {\n    property: 'topic',\n    headerName: ShopifyHeader.Topic,\n  },\n  {\n    property: 'webhookId',\n    headerName: ShopifyHeader.WebhookId,\n  },\n]"
+    }
+  },
+  "CheckWebhookRequestGeneratedType": {
+    "/webhooks/process.ts": {
+      "filePath": "/webhooks/process.ts",
+      "name": "CheckWebhookRequestGeneratedType",
+      "params": [
+        {
+          "name": "rawBody",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/process.ts"
+        },
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "/webhooks/process.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/process.ts",
+        "description": "",
+        "name": "{\n  webhookOk: boolean;\n  errorMessage: string;\n  apiVersion: string;\n  domain: string;\n  hmac: string;\n  topic: string;\n  webhookId: string;\n}",
+        "value": "{\n  webhookOk: boolean;\n  errorMessage: string;\n  apiVersion: string;\n  domain: string;\n  hmac: string;\n  topic: string;\n  webhookId: string;\n}"
+      },
+      "value": "function checkWebhookRequest(\n  rawBody: string,\n  headers: Headers,\n): {\n  webhookOk: boolean;\n  errorMessage: string;\n  apiVersion: string;\n  domain: string;\n  hmac: string;\n  topic: string;\n  webhookId: string;\n} {\n  let retVal = {\n    webhookOk: true,\n    errorMessage: '',\n    apiVersion: '',\n    domain: '',\n    hmac: '',\n    topic: '',\n    webhookId: '',\n  };\n\n  if (rawBody.length) {\n    const missingHeaders: ShopifyHeader[] = [];\n    const headerValues: {[property: string]: string} = {};\n    headerProperties.forEach(({property, headerName}) => {\n      const headerValue = getHeader(headers, headerName);\n      if (headerValue) {\n        headerValues[property] = headerValue;\n      } else {\n        missingHeaders.push(headerName);\n      }\n    });\n\n    if (missingHeaders.length) {\n      retVal.webhookOk = false;\n      retVal.errorMessage = `Missing one or more of the required HTTP headers to process webhooks: [${missingHeaders.join(\n        ', ',\n      )}]`;\n    } else {\n      retVal = {\n        ...retVal,\n        ...headerValues,\n      };\n    }\n  } else {\n    retVal.webhookOk = false;\n    retVal.errorMessage = 'No body was received when processing webhook';\n  }\n\n  return retVal;\n}"
+    }
+  },
+  "ValidateOkWebhookGeneratedType": {
+    "/webhooks/process.ts": {
+      "filePath": "/webhooks/process.ts",
+      "name": "ValidateOkWebhookGeneratedType",
+      "params": [
+        {
+          "name": "secret",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/process.ts"
+        },
+        {
+          "name": "rawBody",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/process.ts"
+        },
+        {
+          "name": "hmac",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/process.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/process.ts",
+        "description": "",
+        "name": "Promise<boolean>",
+        "value": "Promise<boolean>"
+      },
+      "value": "async function validateOkWebhook(\n  secret: string,\n  rawBody: string,\n  hmac: string,\n): Promise<boolean> {\n  const generatedHash = await createSHA256HMAC(\n    secret,\n    rawBody,\n    HashFormat.Base64,\n  );\n\n  return safeCompare(generatedHash, hmac);\n}"
+    }
+  },
+  "ShopifyWebhooksGeneratedType": {
+    "/webhooks/index.ts": {
+      "filePath": "/webhooks/index.ts",
+      "name": "ShopifyWebhooksGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/webhooks/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function shopifyWebhooks(config: ConfigInterface) {\n  const webhookRegistry = registry();\n\n  return {\n    addHandlers: addHandlers(config, webhookRegistry),\n    getTopicsAdded: getTopicsAdded(webhookRegistry),\n    getHandlers: getHandlers(webhookRegistry),\n    register: register(config, webhookRegistry),\n    process: process(config, webhookRegistry),\n  };\n}"
+    }
+  },
+  "ShopifyWebhooks": {
+    "/webhooks/index.ts": {
+      "filePath": "/webhooks/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyWebhooks",
+      "value": "ReturnType<typeof shopifyWebhooks>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "addHandlers",
+          "value": "(handlersToAdd: AddHandlersParams) => Promise<void>",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "getTopicsAdded",
+          "value": "() => string[]",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "getHandlers",
+          "value": "(topic: string) => WebhookHandler[]",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "register",
+          "value": "({ session, }: RegisterParams) => Promise<RegisterReturn>",
+          "description": ""
+        },
+        {
+          "filePath": "/webhooks/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "process",
+          "value": "({ rawBody, ...adapterArgs }: WebhookProcessParams) => Promise<any>",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "CheckInternalParams": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "CheckInternalParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/check.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plans",
+          "value": "string[]",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/check.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/check.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface CheckInternalParams {\n  plans: string[];\n  client: GraphqlClient;\n  isTest: boolean;\n}"
+    }
+  },
+  "CheckInstallationParams": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "CheckInstallationParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/check.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plans",
+          "value": "string[]",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/check.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/check.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "installation",
+          "value": "CurrentAppInstallation",
+          "description": ""
+        }
+      ],
+      "value": "interface CheckInstallationParams {\n  plans: string[];\n  isTest: boolean;\n  installation: CurrentAppInstallation;\n}"
+    }
+  },
+  "CheckResponse": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "CheckResponse",
+      "value": "boolean",
+      "description": "true if there is a payment for any of the given plans, and false otherwise."
+    }
+  },
+  "CheckGeneratedType": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "CheckGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/billing/check.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/check.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function check(config: ConfigInterface) {\n  return async function ({\n    session,\n    plans,\n    isTest = true,\n  }: CheckParams): Promise<CheckResponse> {\n    if (!config.billing) {\n      throw new BillingError({\n        message: 'Attempted to look for purchases without billing configs',\n        errorData: [],\n      });\n    }\n\n    const GraphqlClient = graphqlClientClass({config});\n    const client = new GraphqlClient({session});\n\n    const plansArray = Array.isArray(plans) ? plans : [plans];\n    return hasActivePayment({\n      plans: plansArray,\n      client,\n      isTest,\n    });\n  };\n}"
+    }
+  },
+  "HasActivePaymentGeneratedType": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "HasActivePaymentGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "CheckInternalParams",
+          "filePath": "/billing/check.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/check.ts",
+        "description": "",
+        "name": "Promise<boolean>",
+        "value": "Promise<boolean>"
+      },
+      "value": "async function hasActivePayment({\n  plans,\n  client,\n  isTest,\n}: CheckInternalParams): Promise<boolean> {\n  let installation: CurrentAppInstallation;\n  let endCursor: string | null = null;\n  do {\n    const currentInstallations = await client.query<CurrentAppInstallations>({\n      data: {\n        query: HAS_PAYMENTS_QUERY,\n        variables: {endCursor},\n      },\n    });\n\n    installation = currentInstallations.body.data.currentAppInstallation;\n    if (\n      hasSubscription({plans, isTest, installation}) ||\n      hasOneTimePayment({plans, isTest, installation})\n    ) {\n      return true;\n    }\n\n    endCursor = installation.oneTimePurchases.pageInfo.endCursor;\n  } while (installation?.oneTimePurchases.pageInfo.hasNextPage);\n\n  return false;\n}"
+    }
+  },
+  "HasSubscriptionGeneratedType": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "HasSubscriptionGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "CheckInstallationParams",
+          "filePath": "/billing/check.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/check.ts",
+        "description": "",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "function hasSubscription({\n  plans,\n  isTest,\n  installation,\n}: CheckInstallationParams): boolean {\n  return installation.activeSubscriptions.some(\n    (subscription) =>\n      plans.includes(subscription.name) && (isTest || !subscription.test),\n  );\n}"
+    }
+  },
+  "HasOneTimePaymentGeneratedType": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "HasOneTimePaymentGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "CheckInstallationParams",
+          "filePath": "/billing/check.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/check.ts",
+        "description": "",
+        "name": "boolean",
+        "value": "boolean"
+      },
+      "value": "function hasOneTimePayment({\n  plans,\n  isTest,\n  installation,\n}: CheckInstallationParams): boolean {\n  return installation.oneTimePurchases.edges.some(\n    (purchase) =>\n      plans.includes(purchase.node.name) &&\n      (isTest || !purchase.node.test) &&\n      purchase.node.status === 'ACTIVE',\n  );\n}"
+    }
+  },
+  "HAS_PAYMENTS_QUERYGeneratedType": {
+    "/billing/check.ts": {
+      "filePath": "/billing/check.ts",
+      "name": "HAS_PAYMENTS_QUERYGeneratedType",
+      "value": "HAS_PAYMENTS_QUERY = `\n  query appSubscription($endCursor: String) {\n    currentAppInstallation {\n      activeSubscriptions {\n        name\n        test\n      }\n\n      oneTimePurchases(first: 250, sortKey: CREATED_AT, after: $endCursor) {\n        edges {\n          node {\n            name\n            test\n            status\n          }\n        }\n        pageInfo {\n          hasNextPage\n          endCursor\n        }\n      }\n    }\n  }\n`"
+    }
+  },
+  "RequestInternalParams": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestInternalParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plan",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "returnUrl",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface RequestInternalParams {\n  client: GraphqlClient;\n  plan: string;\n  returnUrl: string;\n  isTest: boolean;\n}"
+    }
+  },
+  "RequestSubscriptionInternalParams": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestSubscriptionInternalParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billingConfig",
+          "value": "BillingConfigSubscriptionPlan",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plan",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "returnUrl",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface RequestSubscriptionInternalParams extends RequestInternalParams {\n  billingConfig: BillingConfigSubscriptionPlan;\n}"
+    }
+  },
+  "RequestOneTimePaymentInternalParams": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestOneTimePaymentInternalParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billingConfig",
+          "value": "BillingConfigOneTimePlan",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plan",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "returnUrl",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface RequestOneTimePaymentInternalParams extends RequestInternalParams {\n  billingConfig: BillingConfigOneTimePlan;\n}"
+    }
+  },
+  "RequestUsageSubscriptionInternalParams": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestUsageSubscriptionInternalParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billingConfig",
+          "value": "BillingConfigUsagePlan",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "client",
+          "value": "GraphqlClient",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plan",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "returnUrl",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/request.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": ""
+        }
+      ],
+      "value": "interface RequestUsageSubscriptionInternalParams extends RequestInternalParams {\n  billingConfig: BillingConfigUsagePlan;\n}"
+    }
+  },
+  "BillingRequestResponse": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "BillingRequestResponse",
+      "value": "string",
+      "description": "The URL to confirm the charge with the merchant - the library will not redirect right away to make it possible for apps to run their own code after it creates the payment request.\nThe app must redirect the merchant to this URL so that they can confirm the charge before Shopify applies it. The merchant will be sent back to the app's main page after the process is complete."
+    }
+  },
+  "RequestGeneratedType": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/billing/request.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/request.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function request(config: ConfigInterface) {\n  return async function ({\n    session,\n    plan,\n    isTest = true,\n  }: RequestParams): Promise<BillingRequestResponse> {\n    if (!config.billing || !config.billing[plan]) {\n      throw new BillingError({\n        message: `Could not find plan ${plan} in billing settings`,\n        errorData: [],\n      });\n    }\n\n    const billingConfig = config.billing[plan];\n\n    const returnUrl = buildEmbeddedAppUrl(config)(\n      hashString(`${session.shop}/admin`, HashFormat.Base64),\n    );\n\n    const GraphqlClient = graphqlClientClass({config});\n    const client = new GraphqlClient({session});\n\n    let data: RequestResponse;\n    switch (billingConfig.interval) {\n      case BillingInterval.OneTime: {\n        const mutationOneTimeResponse = await requestSinglePayment({\n          billingConfig: billingConfig as BillingConfigOneTimePlan,\n          plan,\n          client,\n          returnUrl,\n          isTest,\n        });\n        data = mutationOneTimeResponse.data.appPurchaseOneTimeCreate;\n        break;\n      }\n      case BillingInterval.Usage: {\n        const mutationUsageResponse = await requestUsagePayment({\n          billingConfig: billingConfig as BillingConfigUsagePlan,\n          plan,\n          client,\n          returnUrl,\n          isTest,\n        });\n        data = mutationUsageResponse.data.appSubscriptionCreate;\n        break;\n      }\n      default: {\n        const mutationRecurringResponse = await requestRecurringPayment({\n          billingConfig: billingConfig as BillingConfigSubscriptionPlan,\n          plan,\n          client,\n          returnUrl,\n          isTest,\n        });\n        data = mutationRecurringResponse.data.appSubscriptionCreate;\n      }\n    }\n    if (data.userErrors?.length) {\n      throw new BillingError({\n        message: 'Error while billing the store',\n        errorData: data.userErrors,\n      });\n    }\n\n    return data.confirmationUrl;\n  };\n}"
+    }
+  },
+  "RequestRecurringPaymentGeneratedType": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestRecurringPaymentGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "RequestSubscriptionInternalParams",
+          "filePath": "/billing/request.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/request.ts",
+        "description": "",
+        "name": "Promise<RecurringPaymentResponse>",
+        "value": "Promise<RecurringPaymentResponse>"
+      },
+      "value": "async function requestRecurringPayment({\n  billingConfig,\n  plan,\n  client,\n  returnUrl,\n  isTest,\n}: RequestSubscriptionInternalParams): Promise<RecurringPaymentResponse> {\n  const mutationResponse = await client.query<RecurringPaymentResponse>({\n    data: {\n      query: RECURRING_PURCHASE_MUTATION,\n      variables: {\n        name: plan,\n        trialDays: billingConfig.trialDays,\n        replacementBehavior: billingConfig.replacementBehavior,\n        returnUrl,\n        test: isTest,\n        lineItems: [\n          {\n            plan: {\n              appRecurringPricingDetails: {\n                interval: billingConfig.interval,\n                price: {\n                  amount: billingConfig.amount,\n                  currencyCode: billingConfig.currencyCode,\n                },\n              },\n            },\n          },\n        ],\n      },\n    },\n  });\n\n  if (mutationResponse.body.errors?.length) {\n    throw new BillingError({\n      message: 'Error while billing the store',\n      errorData: mutationResponse.body.errors,\n    });\n  }\n\n  return mutationResponse.body;\n}"
+    }
+  },
+  "RequestUsagePaymentGeneratedType": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestUsagePaymentGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "RequestUsageSubscriptionInternalParams",
+          "filePath": "/billing/request.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/request.ts",
+        "description": "",
+        "name": "Promise<RecurringPaymentResponse>",
+        "value": "Promise<RecurringPaymentResponse>"
+      },
+      "value": "async function requestUsagePayment({\n  billingConfig,\n  plan,\n  client,\n  returnUrl,\n  isTest,\n}: RequestUsageSubscriptionInternalParams): Promise<RecurringPaymentResponse> {\n  const mutationResponse = await client.query<RecurringPaymentResponse>({\n    data: {\n      query: RECURRING_PURCHASE_MUTATION,\n      variables: {\n        name: plan,\n        returnUrl,\n        test: isTest,\n        lineItems: [\n          {\n            plan: {\n              appUsagePricingDetails: {\n                terms: billingConfig.usageTerms,\n                cappedAmount: {\n                  amount: billingConfig.amount,\n                  currencyCode: billingConfig.currencyCode,\n                },\n              },\n            },\n          },\n        ],\n      },\n    },\n  });\n\n  if (mutationResponse.body.errors?.length) {\n    throw new BillingError({\n      message: `Error while billing the store:: ${mutationResponse.body.errors}`,\n      errorData: mutationResponse.body.errors,\n    });\n  }\n\n  return mutationResponse.body;\n}"
+    }
+  },
+  "RequestSinglePaymentGeneratedType": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RequestSinglePaymentGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "RequestOneTimePaymentInternalParams",
+          "filePath": "/billing/request.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/request.ts",
+        "description": "",
+        "name": "Promise<SinglePaymentResponse>",
+        "value": "Promise<SinglePaymentResponse>"
+      },
+      "value": "async function requestSinglePayment({\n  billingConfig,\n  plan,\n  client,\n  returnUrl,\n  isTest,\n}: RequestOneTimePaymentInternalParams): Promise<SinglePaymentResponse> {\n  const mutationResponse = await client.query<SinglePaymentResponse>({\n    data: {\n      query: ONE_TIME_PURCHASE_MUTATION,\n      variables: {\n        name: plan,\n        returnUrl,\n        test: isTest,\n        price: {\n          amount: billingConfig.amount,\n          currencyCode: billingConfig.currencyCode,\n        },\n      },\n    },\n  });\n\n  if (mutationResponse.body.errors?.length) {\n    throw new BillingError({\n      message: 'Error while billing the store',\n      errorData: mutationResponse.body.errors,\n    });\n  }\n\n  return mutationResponse.body;\n}"
+    }
+  },
+  "RECURRING_PURCHASE_MUTATIONGeneratedType": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "RECURRING_PURCHASE_MUTATIONGeneratedType",
+      "value": "RECURRING_PURCHASE_MUTATION = `\n  mutation test(\n    $name: String!\n    $lineItems: [AppSubscriptionLineItemInput!]!\n    $returnUrl: URL!\n    $test: Boolean\n    $trialDays: Int\n    $replacementBehavior: AppSubscriptionReplacementBehavior\n  ) {\n    appSubscriptionCreate(\n      name: $name\n      lineItems: $lineItems\n      returnUrl: $returnUrl\n      test: $test\n      trialDays: $trialDays\n      replacementBehavior: $replacementBehavior\n    ) {\n      confirmationUrl\n      userErrors {\n        field\n        message\n      }\n    }\n  }\n`"
+    }
+  },
+  "ONE_TIME_PURCHASE_MUTATIONGeneratedType": {
+    "/billing/request.ts": {
+      "filePath": "/billing/request.ts",
+      "name": "ONE_TIME_PURCHASE_MUTATIONGeneratedType",
+      "value": "ONE_TIME_PURCHASE_MUTATION = `\n  mutation test(\n    $name: String!\n    $price: MoneyInput!\n    $returnUrl: URL!\n    $test: Boolean\n  ) {\n    appPurchaseOneTimeCreate(\n      name: $name\n      price: $price\n      returnUrl: $returnUrl\n      test: $test\n    ) {\n      confirmationUrl\n      userErrors {\n        field\n        message\n      }\n    }\n  }\n`"
+    }
+  },
+  "ShopifyBillingGeneratedType": {
+    "/billing/index.ts": {
+      "filePath": "/billing/index.ts",
+      "name": "ShopifyBillingGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "",
+          "value": "ConfigInterface",
+          "filePath": "/billing/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/index.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function shopifyBilling(config: ConfigInterface) {\n  return {\n    check: check(config),\n    request: request(config),\n  };\n}"
+    }
+  },
+  "ShopifyBilling": {
+    "/billing/index.ts": {
+      "filePath": "/billing/index.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyBilling",
+      "value": "ReturnType<typeof shopifyBilling>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/billing/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "check",
+          "value": "({ session, plans, isTest, }: CheckParams) => Promise<boolean>",
+          "description": ""
+        },
+        {
+          "filePath": "/billing/index.ts",
+          "syntaxKind": "PropertyAssignment",
+          "name": "request",
+          "value": "({ session, plan, isTest, }: RequestParams) => Promise<string>",
+          "description": ""
+        }
+      ]
+    }
+  },
+  "ShopifyGeneratedType": {
+    "/index.ts": {
+      "filePath": "/index.ts",
+      "name": "ShopifyGeneratedType",
+      "value": "Shopify: DeprecatedV5Types = {}"
+    },
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "ShopifyGeneratedType",
+      "value": "shopify: Shopify"
+    },
+    "/docs/examples/shopify-api.example.ts": {
+      "filePath": "/docs/examples/shopify-api.example.ts",
+      "name": "ShopifyGeneratedType",
+      "value": "shopify = shopifyApi({\n  apiKey: 'APIKeyFromPartnersDashboard',\n  apiSecretKey: 'APISecretFromPartnersDashboard',\n  scopes: ['read_products'],\n  hostName: 'localhost:4321',\n  hostScheme: 'http',\n  apiVersion: ApiVersion.July22,\n  isEmbeddedApp: true,\n  isCustomStoreApp: false,\n  userAgentPrefix: 'Custom prefix',\n  privateAppStorefrontAccessToken: 'PrivateAccessToken',\n  customShopDomains: ['*.my-custom-domain.io'],\n  billing: {\n    'My plan': {\n      amount: 5.0,\n      currencyCode: 'USD',\n      interval: BillingInterval.OneTime,\n    },\n  },\n  logger: {\n    log: (severity, message) => {\n      myAppsLogFunction(severity, message);\n    },\n  },\n  restResources,\n})"
+    },
+    "/utils/docs/examples/version-compatible.example.ts": {
+      "filePath": "/utils/docs/examples/version-compatible.example.ts",
+      "name": "ShopifyGeneratedType",
+      "value": "shopify = shopifyApi({\n  apiVersion: ApiVersion.July22,\n})"
+    }
+  },
+  "Shopify": {
+    "/index.ts": {
+      "filePath": "/index.ts",
+      "name": "Shopify",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "config",
+          "value": "ConfigInterface",
+          "description": "The options used to set up the object, containing the validated parameters of the `shopifyApi` function."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "clients",
+          "value": "ShopifyClients",
+          "description": "Object containing clients to access Shopify APIs."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "auth",
+          "value": "ShopifyAuth",
+          "description": "Object containing functions to authenticate with Shopify APIs."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "ShopifySession",
+          "description": "Object containing functions to manage Shopify sessions."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "utils",
+          "value": "ShopifyUtils",
+          "description": "Object containing general functions to help build apps."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "webhooks",
+          "value": "ShopifyWebhooks",
+          "description": "Object containing functions to configure and handle Shopify webhooks."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billing",
+          "value": "ShopifyBilling",
+          "description": "Object containing functions to enable apps to bill merchants."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "logger",
+          "value": "ShopifyLogger",
+          "description": "Object containing functions to log messages."
+        },
+        {
+          "filePath": "/index.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rest",
+          "value": "T",
+          "description": "Object containing object-oriented representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/docs/api/admin-rest) for details."
+        }
+      ],
+      "value": "export interface Shopify<\n  T extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /** The options used to set up the object, containing the validated parameters of the `shopifyApi` function. */\n  config: ConfigInterface;\n  /** Object containing clients to access Shopify APIs. */\n  clients: ShopifyClients;\n  /** Object containing functions to authenticate with Shopify APIs. */\n  auth: ShopifyAuth;\n  /** Object containing functions to manage Shopify sessions. */\n  session: ShopifySession;\n  /** Object containing general functions to help build apps. */\n  utils: ShopifyUtils;\n  /** Object containing functions to configure and handle Shopify webhooks. */\n  webhooks: ShopifyWebhooks;\n  /** Object containing functions to enable apps to bill merchants. */\n  billing: ShopifyBilling;\n  /** Object containing functions to log messages. */\n  logger: ShopifyLogger;\n  /** Object containing object-oriented representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/docs/api/admin-rest) for details. */\n  rest: T;\n}"
+    }
+  },
+  "ShopifyApiGeneratedType": {
+    "/index.ts": {
+      "filePath": "/index.ts",
+      "name": "ShopifyApiGeneratedType",
+      "params": [
+        {
+          "name": "config",
+          "description": "Configuration object",
+          "value": "ConfigParams<T>",
+          "filePath": "/index.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/index.ts",
+        "description": "object containing validated config, client classes, and library methods",
+        "name": "Shopify<T>",
+        "value": "Shopify<T>"
+      },
+      "value": "export function shopifyApi<T extends ShopifyRestResources>(\n  config: ConfigParams<T>,\n): Shopify<T> {\n  const {restResources, ...libConfig} = config;\n  const validatedConfig = validateConfig(libConfig);\n\n  const shopify: Shopify<T> = {\n    config: validatedConfig,\n    clients: clientClasses(validatedConfig),\n    auth: shopifyAuth(validatedConfig),\n    session: shopifySession(validatedConfig),\n    utils: shopifyUtils(validatedConfig),\n    webhooks: shopifyWebhooks(validatedConfig),\n    billing: shopifyBilling(validatedConfig),\n    logger: logger(validatedConfig),\n    rest: {} as T,\n  };\n\n  if (restResources) {\n    shopify.rest = loadRestResources({\n      resources: restResources,\n      config: validatedConfig,\n      RestClient: shopify.clients.Rest,\n    }) as T;\n  }\n\n  shopify.logger\n    .info(\n      `version ${SHOPIFY_API_LIBRARY_VERSION}, environment ${abstractRuntimeString()}`,\n    )\n    .catch((err) => console.log(err));\n\n  return shopify;\n}"
+    }
+  },
+  "RequestListEntry": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RequestListEntry",
+      "value": "NormalizedRequest",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "method",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "url",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "Headers",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "body",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        }
+      ]
+    }
+  },
+  "ResponseListEntry": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ResponseListEntry",
+      "value": "NormalizedResponse | Error",
+      "description": ""
+    }
+  },
+  "MockedAdapter": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+      "name": "MockedAdapter",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "requestList",
+          "value": "NormalizedRequest[]",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "responseList",
+          "value": "ResponseListEntry[]",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "queueResponse",
+          "value": "(response: NormalizedResponse) => void",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "queueError",
+          "value": "(error: Error) => void",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "getRequest",
+          "value": "() => NormalizedRequest",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "getResponses",
+          "value": "() => ResponseListEntry[]",
+          "description": ""
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "reset",
+          "value": "() => void",
+          "description": ""
+        }
+      ],
+      "value": "interface MockedAdapter {\n  requestList: RequestListEntry[];\n  responseList: ResponseListEntry[];\n  queueResponse: (response: NormalizedResponse) => void;\n  queueError: (error: Error) => void;\n  getRequest: () => RequestListEntry | undefined;\n  getResponses: () => ResponseListEntry[];\n  reset: () => void;\n}"
+    }
+  },
+  "MockTestRequestsGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/mock_test_requests.ts",
+      "name": "MockTestRequestsGeneratedType",
+      "value": "mockTestRequests: MockedAdapter = {\n  requestList: [],\n  responseList: [],\n\n  queueResponse(response: NormalizedResponse): void {\n    this.responseList.push(response);\n  },\n\n  queueError(error: Error): void {\n    this.responseList.push(error);\n  },\n\n  getRequest(): RequestListEntry | undefined {\n    return this.requestList.shift();\n  },\n\n  getResponses(): ResponseListEntry[] {\n    return this.responseList;\n  },\n\n  reset() {\n    this.requestList = [];\n    this.responseList = [];\n  },\n}"
+    }
+  },
+  "MockAdapterArgs": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+      "name": "MockAdapterArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawRequest",
+          "value": "NormalizedRequest",
+          "description": "The HTTP Request object used by your runtime."
+        },
+        {
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rawResponse",
+          "value": "AdapterResponse",
+          "description": "The HTTP Response object used by your runtime. Required for Node.js.",
+          "isOptional": true
+        }
+      ],
+      "value": "interface MockAdapterArgs extends AdapterArgs {\n  rawRequest: NormalizedRequest;\n}"
+    }
+  },
+  "MockConvertRequestGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+      "name": "MockConvertRequestGeneratedType",
+      "params": [
+        {
+          "name": "adapterArgs",
+          "description": "",
+          "value": "MockAdapterArgs",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+        "description": "",
+        "name": "Promise<NormalizedRequest>",
+        "value": "Promise<NormalizedRequest>"
+      },
+      "value": "export async function mockConvertRequest(\n  adapterArgs: MockAdapterArgs,\n): Promise<NormalizedRequest> {\n  return Promise.resolve(adapterArgs.rawRequest);\n}"
+    }
+  },
+  "MockConvertResponseGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+      "name": "MockConvertResponseGeneratedType",
+      "params": [
+        {
+          "name": "response",
+          "description": "",
+          "value": "NormalizedResponse",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts"
+        },
+        {
+          "name": "_adapterArgs",
+          "description": "",
+          "value": "MockAdapterArgs",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+        "description": "",
+        "name": "Promise<NormalizedResponse>",
+        "value": "Promise<NormalizedResponse>"
+      },
+      "value": "export async function mockConvertResponse(\n  response: NormalizedResponse,\n  _adapterArgs: MockAdapterArgs,\n): Promise<NormalizedResponse> {\n  return Promise.resolve(response);\n}"
+    }
+  },
+  "MockConvertHeadersGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+      "name": "MockConvertHeadersGeneratedType",
+      "params": [
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts"
+        },
+        {
+          "name": "_adapterArgs",
+          "description": "",
+          "value": "MockAdapterArgs",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+        "description": "",
+        "name": "Promise<AdapterHeaders>",
+        "value": "Promise<AdapterHeaders>"
+      },
+      "value": "export async function mockConvertHeaders(\n  headers: Headers,\n  _adapterArgs: MockAdapterArgs,\n): Promise<AdapterHeaders> {\n  return Promise.resolve(headers);\n}"
+    }
+  },
+  "MockFetchGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+      "name": "MockFetchGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "NormalizedRequest",
+          "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+        "description": "",
+        "name": "Promise<NormalizedResponse>",
+        "value": "Promise<NormalizedResponse>"
+      },
+      "value": "export async function mockFetch({\n  url,\n  method,\n  headers = {},\n  body,\n}: NormalizedRequest): Promise<NormalizedResponse> {\n  mockTestRequests.requestList.push({\n    url,\n    method,\n    headers: canonicalizeHeaders(headers),\n    body,\n  });\n\n  const next = mockTestRequests.responseList.shift()!;\n  if (!next) {\n    throw new Error(\n      `Missing mock for ${method} to ${url}, have you queued all required responses?`,\n    );\n  }\n  if (next instanceof Error) {\n    throw next;\n  }\n  return next;\n}"
+    }
+  },
+  "MockRuntimeStringGeneratedType": {
+    "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts": {
+      "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+      "name": "MockRuntimeStringGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "Users/kevinosullivan/src/github.com/Shopify/shopify-api-js/adapters/mock/adapter.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function mockRuntimeString() {\n  return 'Mock adapter';\n}"
+    }
+  },
+  "AssertHttpRequestParams": {
+    "/setup-jest.ts": {
+      "filePath": "/setup-jest.ts",
+      "name": "AssertHttpRequestParams",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "method",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "domain",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "path",
+          "value": "string",
+          "description": ""
+        },
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "query",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "{ [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "data",
+          "value": "string | { [key: string]: unknown; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/setup-jest.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "attempts",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface AssertHttpRequestParams {\n  method: string;\n  domain: string;\n  path: string;\n  query?: string;\n  headers?: {[key: string]: unknown};\n  data?: string | {[key: string]: unknown} | null;\n  attempts?: number;\n}"
+    }
+  },
+  "TestConfigGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "TestConfigGeneratedType",
+      "value": "testConfig: ConfigParams"
+    }
+  },
+  "GetNewTestConfigGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "GetNewTestConfigGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "ConfigParams",
+        "value": "ConfigParams"
+      },
+      "value": "export function getNewTestConfig(): ConfigParams {\n  return {\n    apiKey: 'test_key',\n    apiSecretKey: 'test_secret_key',\n    scopes: ['test_scope'],\n    hostName: 'test_host_name',\n    hostScheme: 'https',\n    apiVersion: LATEST_API_VERSION,\n    isEmbeddedApp: false,\n    isCustomStoreApp: false,\n    customShopDomains: undefined,\n    billing: undefined,\n    logger: {\n      log: jest.fn(),\n      level: LogSeverity.Debug,\n      httpRequests: false,\n      timestamps: false,\n    },\n  };\n}"
+    }
+  },
+  "SignJWTGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "SignJWTGeneratedType",
+      "params": [
+        {
+          "name": "secret",
+          "description": "",
+          "value": "string",
+          "filePath": "/__tests__/test-helper.ts"
+        },
+        {
+          "name": "payload",
+          "description": "",
+          "value": "JwtPayload",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "Promise<string>",
+        "value": "Promise<string>"
+      },
+      "value": "export async function signJWT(\n  secret: string,\n  payload: JwtPayload,\n): Promise<string> {\n  return new jose.SignJWT(payload as any)\n    .setProtectedHeader({alg: 'HS256'})\n    .sign(getHMACKey(secret));\n}"
+    }
+  },
+  "BuildMockResponseGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "BuildMockResponseGeneratedType",
+      "params": [
+        {
+          "name": "obj",
+          "description": "",
+          "value": "unknown",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "string",
+        "value": "string"
+      },
+      "value": "export function buildMockResponse(obj: unknown): string {\n  return JSON.stringify(obj);\n}"
+    }
+  },
+  "BuildExpectedResponseGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "BuildExpectedResponseGeneratedType",
+      "params": [
+        {
+          "name": "obj",
+          "description": "",
+          "value": "unknown",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "RequestReturn",
+        "value": "RequestReturn"
+      },
+      "value": "export function buildExpectedResponse(obj: unknown): RequestReturn {\n  const expectedResponse: RequestReturn = {\n    body: obj,\n    headers: expect.objectContaining({}),\n  };\n\n  return expect.objectContaining(expectedResponse);\n}"
+    }
+  },
+  "QueueMockResponseGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "QueueMockResponseGeneratedType",
+      "params": [
+        {
+          "name": "body",
+          "description": "",
+          "value": "string",
+          "filePath": "/__tests__/test-helper.ts"
+        },
+        {
+          "name": "partial",
+          "description": "",
+          "value": "Partial<NormalizedResponse>",
+          "isOptional": true,
+          "defaultValue": "{}",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function queueMockResponse(\n  body: string,\n  partial: Partial<NormalizedResponse> = {},\n) {\n  mockTestRequests.queueResponse({\n    statusCode: partial.statusCode ?? 200,\n    statusText: partial.statusText ?? 'OK',\n    headers: canonicalizeHeaders(partial.headers ?? {}),\n    body,\n  });\n}"
+    }
+  },
+  "QueueErrorGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "QueueErrorGeneratedType",
+      "params": [
+        {
+          "name": "error",
+          "description": "",
+          "value": "Error",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function queueError(error: Error) {\n  mockTestRequests.queueError(error);\n}"
+    }
+  },
+  "QueueMockResponsesGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "QueueMockResponsesGeneratedType",
+      "params": [
+        {
+          "name": "responses",
+          "description": "",
+          "value": "[body: string, partial?: Partial<NormalizedResponse>][]",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function queueMockResponses(\n  ...responses: Parameters<typeof queueMockResponse>[]\n) {\n  for (const [body, response] of responses) {\n    queueMockResponse(body, response);\n  }\n}"
+    }
+  },
+  "SetSignedSessionCookieGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "SetSignedSessionCookieGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "{ request: NormalizedRequest; cookieId: string; }",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export async function setSignedSessionCookie({\n  request,\n  cookieId,\n}: {\n  request: NormalizedRequest;\n  cookieId: string;\n}) {\n  const cookies = new Cookies(request, {} as NormalizedResponse, {\n    keys: [shopify.config.apiSecretKey],\n  });\n  await cookies.setAndSign('shopify_app_session', cookieId, {\n    secure: true,\n  });\n\n  // eslint-disable-next-line require-atomic-updates\n  request.headers.Cookie = cookies.toHeaders().join(';');\n}"
+    }
+  },
+  "CreateDummySessionGeneratedType": {
+    "/__tests__/test-helper.ts": {
+      "filePath": "/__tests__/test-helper.ts",
+      "name": "CreateDummySessionGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "{ sessionId: string; isOnline: boolean; shop?: string; expires?: Date; accessToken?: string; }",
+          "filePath": "/__tests__/test-helper.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/__tests__/test-helper.ts",
+        "description": "",
+        "name": "Promise<Session>",
+        "value": "Promise<Session>"
+      },
+      "value": "export async function createDummySession({\n  sessionId,\n  isOnline,\n  shop = 'test-shop.myshopify.io',\n  expires = undefined,\n  accessToken = undefined,\n}: {\n  sessionId: string;\n  isOnline: boolean;\n  shop?: string;\n  expires?: Date;\n  accessToken?: string;\n}): Promise<Session> {\n  const session = new Session({\n    id: sessionId,\n    shop,\n    state: 'state',\n    isOnline,\n    expires,\n    accessToken,\n  });\n\n  return session;\n}"
+    }
+  },
+  "DataGeneratedType": {
+    "/docs/shopify-api.doc.ts": {
+      "filePath": "/docs/shopify-api.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'shopifyApi',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    'Creates a new library object that provides all features needed for an app to interact with Shopify APIs.\\n\\nUse this function when you set up your app.',\n  // Optional. A short sentence of what is needed to use this entity, such as a version dependency.\n  requires: '',\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: 'Entry point',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // Optional. If used will cause the card to only be visible when the feature flag is enabled.\n    featureFlag: '',\n    // Optional. An image preview of the example.\n    image: '',\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // Optional. The title of the tab.\n          title: 'JS',\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/shopify-api.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'Create the Shopify API library',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      // Title of the list of definitions.\n      title: 'config',\n      // Description of the definitions. Can use Markdown.\n      description: 'Parameter passed into `shopifyApi`.',\n      // Name of the TypeScript type this entity uses.\n      type: 'ConfigParams',\n    },\n    {\n      // Title of the list of definitions.\n      title: 'Shopify',\n      // Description of the definitions. Can use Markdown.\n      description: 'Object returned by `shopifyApi`.',\n      // Name of the TypeScript type this entity uses.\n      type: 'Shopify',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'Entry point',\n  // Optional. A thumbnail image to display in the category page.\n  thumbnail: '',\n  related: [],\n}"
+    },
+    "/auth/docs/build-embedded-app-url.doc.ts": {
+      "filePath": "/auth/docs/build-embedded-app-url.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'buildEmbeddedAppURL',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    'Constructs the redirection URL for [getEmbeddedAppUrl](/docs/api/shopify-api-js/auth/getembeddedappurl) based on the given `host`.\\n\\nThis utility relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.',\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: '',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/build-embedded-app-url.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'buildEmbeddedAppURL',\n    },\n  },\n  // This determines where in the sidebar the entity will appear.\n  category: 'auth',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/auth/docs/get-embedded-app-url.doc.ts": {
+      "filePath": "/auth/docs/get-embedded-app-url.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'getEmbeddedAppUrl',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    'If you need to redirect a request to your embedded app URL you can use `getEmbeddedAppUrl`.\\n\\nUsing this method ensures that the embedded app URL is properly constructed and brings the merchant to the right place. It is more reliable than using the shop param.\\n\\nThis method relies on the host query param being a Base 64 encoded string. All requests from Shopify should include this param in the correct format.',\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: 'async',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/get-embedded-app-url.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'getEmbeddedAppUrl',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      // Title of the list of definitions.\n      title: 'getEmbeddedAppUrl Parameters',\n      // Description of the definitions. Can use Markdown.\n      description: 'Parameters for the `getEmbeddedAppUrl` function.',\n      // Name of the TypeScript type this entity uses.\n      type: 'GetEmbeddedAppUrlParams',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'auth',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/billing/docs/check.doc.ts": {
+      "filePath": "/billing/docs/check.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'check',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    \"Checks if a payment exists for any of the given plans, by querying the Shopify Admin API.\\n\\n > Note: \\nDepending on the number of requests your app handles, you might want to cache a merchant's payment status, but you should periodically call this method to ensure you're blocking unpaid access.\",\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: 'async',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/check.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'check',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      title: 'check Parameters',\n      description: 'Parameters for the `check` function.',\n      type: 'CheckParams',\n    },\n    {\n      title: 'check Return',\n      description:\n        '`true` if there is a payment for any of the given plans, and `false` otherwise.',\n      type: 'CheckResponse',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'billing',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/billing/docs/request.doc.ts": {
+      "filePath": "/billing/docs/request.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'request',\n  description: 'Creates a new charge for the merchant, for the given plan.',\n  type: 'async',\n  isVisualComponent: false,\n  defaultExample: {\n    codeblock: {\n      tabs: [\n        {\n          title: 'Single-plan setup - charge after OAuth completes',\n          code: './examples/request.single-plan.example.ts',\n          language: 'js',\n        },\n        {\n          title: 'Multi-plan setup - charge based on user selection',\n          code: './examples/request.multi-plan.example.ts',\n          language: 'js',\n        },\n      ],\n      title: 'request',\n    },\n  },\n  definitions: [\n    {\n      // Title of the list of definitions.\n      title: 'request Parameters',\n      // Description of the definitions. Can use Markdown.\n      description: 'Parameters for the `request` function.',\n      // Name of the TypeScript type this entity uses.\n      type: 'RequestParams',\n    },\n    {\n      title: 'request Return',\n      description:\n        \"The URL to confirm the charge with the merchant - we don't redirect right away to make it possible for apps to run their own code after it creates the payment request.\\n\\nThe app must redirect the merchant to this URL so that they can confirm the charge before Shopify applies it. The merchant will be sent back to your app's main page after the process is complete.\",\n      type: 'BillingRequestResponse',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'billing',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/session/docs/get-current-id.doc.ts": {
+      "filePath": "/session/docs/get-current-id.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'getCurrentId',\n  description:\n    'Extracts the Shopify session id from the given request.\\n\\nFor embedded apps, `getCurrentId` will only be able to find a session id if you use `authenticatedFetch` from the `@shopify/app-bridge-utils` client-side package.\\n\\nThis function behaves like a [normal `fetch` call](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), but ensures the appropriate headers are set.\\n\\nLearn more about [making authenticated requests](https://shopify.dev/docs/apps/auth/oauth/session-tokens/getting-started#step-2-authenticate-your-requests) using App Bridge.\\n\\n> Note:\\nThis method will rely on cookies for non-embedded apps, and the `Authorization` HTTP header for embedded apps using [App Bridge session tokens](https://shopify.dev/docs/apps/auth/oauth/session-tokens), making all apps safe to use in modern browsers that block 3rd party cookies.',\n  type: 'async',\n  isVisualComponent: false,\n  defaultExample: {\n    codeblock: {\n      tabs: [\n        {\n          code: './examples/get-current-id.example.ts',\n          language: 'js',\n        },\n      ],\n      title: 'getCurrentId',\n    },\n  },\n  definitions: [\n    {\n      title: 'Parameters',\n      description: '',\n      type: 'GetCurrentSessionIdParams',\n    },\n    {\n      title: 'Returns',\n      description:\n        'The session id for the request, or `undefined` if none was found.',\n      type: 'GetCurrentIdReturns',\n    },\n  ],\n  category: 'session',\n  related: [],\n}"
+    },
+    "/session/docs/get-offline-id.doc.ts": {
+      "filePath": "/session/docs/get-offline-id.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'getOfflineId',\n  description:\n    'Builds a session id that can be used to load an offline session, if there was a [`auth.begin`](/docs/api/shopify-api-js/auth/begin) call to create one.\\n\\n> Caution:\\nThis method **_does not_** perform any validation on the `shop` parameter because it is meant for background tasks. You should **_never_** read the shop from user inputs or URLs.',\n  type: '',\n  isVisualComponent: false,\n  defaultExample: {\n    codeblock: {\n      tabs: [\n        {\n          code: './examples/get-current-id.example.ts',\n          language: 'js',\n        },\n      ],\n      title: 'getOfflineId',\n    },\n  },\n  definitions: [\n    {\n      title: 'Props',\n      description: '',\n      type: 'GetOfflineIdFunction',\n    },\n    // {\n    //   title: 'Parameters',\n    //   description: '',\n    //   type: 'GetOfflineIdParams',\n    // },\n    // {\n    //   title: 'Returns',\n    //   description:\n    //     'The `shop` value if it is a properly formatted Shopify shop domain, otherwise `null`.',\n    //   type: 'GetOfflineIdReturns',\n    // },\n  ],\n  category: 'session',\n  related: [],\n}"
+    },
+    "/auth/oauth/docs/begin.doc.ts": {
+      "filePath": "/auth/oauth/docs/begin.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'begin',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    'Begins the OAuth process by redirecting the merchant to the Shopify Authentication screen, where they will be asked to approve the required app scopes.',\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: 'async',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // Optional. The title of the tab.\n          title: 'Node.js',\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/begin.node.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n        {\n          // Optional. The title of the tab.\n          title: 'Cloudflare Workers',\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/begin.cloudflare.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'begin an OAuth process',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      // Title of the list of definitions.\n      title: 'begin Parameters',\n      // Description of the definitions. Can use Markdown.\n      description: 'Parameters for the `begin` function.',\n      // Name of the TypeScript type this entity uses.\n      type: 'BeginParams',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'auth',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/auth/oauth/docs/callback.doc.ts": {
+      "filePath": "/auth/oauth/docs/callback.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'callback',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    \"Process Shopify's callback request after the user approves the app installation. Once the merchant approves the app's request for scopes, Shopify will redirect them back to your app, using the `callbackPath` parameter from `auth.begin`.\\n\\nYour app must then call `auth.callback` to complete the OAuth process, which will create a new Shopify `Session` and return the appropriate HTTP headers your app with which your app must respond.\",\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: 'async',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // Optional. The title of the tab.\n          title: 'Node.js',\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/callback.node.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n        {\n          // Optional. The title of the tab.\n          title: 'Cloudflare Workers',\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/callback.cloudflare.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'complete the OAuth process',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      title: 'callback Parameters',\n      description: 'Parameters for the `callback` function.',\n      type: 'CallbackParams',\n    },\n    {\n      title: 'callback Return',\n      description: 'Return type of the `callback` function.',\n      type: 'CallbackResponse',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'auth',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/auth/oauth/docs/nonce.doc.ts": {
+      "filePath": "/auth/oauth/docs/nonce.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'nonce',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    'Generates a string of 15 characters that are cryptographically random, suitable for short-lived values in cookies to aid validation of requests/responses.',\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: '',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/nonce.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'nonce',\n    },\n  },\n  definitions: [\n    {\n      title: 'Props',\n      description: '',\n      type: 'NonceGeneratedType',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'auth',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/auth/oauth/docs/safe-compare.doc.ts": {
+      "filePath": "/auth/oauth/docs/safe-compare.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'safeCompare',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    \"Takes a pair of arguments (see below for acceptable types) and returns true if they are identical, both in term of type and content.\\n\\nThrows a `SafeCompareError` if the types don't match.\",\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: '',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/safe-compare.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'safeCompare',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      // Title of the list of definitions.\n      title: 'Props',\n      // Description of the definitions. Can use Markdown.\n      description: '',\n      // Name of the TypeScript type this entity uses.\n      type: 'SafeCompareGeneratedType',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'auth',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/utils/docs/hmac-validator.doc.ts": {
+      "filePath": "/utils/docs/hmac-validator.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  // The title of the page.\n  name: 'validateHmac',\n  // Optional. A description of the reference entity. Can include Markdown.\n  description:\n    'Shopify requests include an `hmac` query argument. This method validates those requests to ensure that the `hmac` value was signed by Shopify and not spoofed.',\n  // Optional. What category the entity is: component, hook, utility, etc.\n  type: 'async',\n  // Boolean that determines if the entity is a visual component.\n  isVisualComponent: false,\n  // Optional. The example that appears in the right hand column at the top of the page. Represents the primary use case.\n  defaultExample: {\n    // The data for the codeblock.\n    codeblock: {\n      // Tabs that appear at the top of the codeblock.\n      tabs: [\n        {\n          // The relative file path to the code file. Content will be automatically extracted from that file.\n          code: './examples/hmac-validator.example.ts',\n          // Optional. The name of the language of the code.\n          language: 'js',\n        },\n      ],\n      // The title of the codeblock.\n      title: 'validateHmac',\n    },\n  },\n  // Optional. Displays generated TypeScript information, such as prop tables.\n  definitions: [\n    {\n      title: 'validateHmac Parameters',\n      description: 'Parameters for the `validateHmac` function.',\n      type: 'AuthQuery',\n    },\n    {\n      title: 'validateHmac Return',\n      description:\n        '`true` if the `hmac` value in the query is valid, and `false` otherwise.',\n      type: 'ValidateHmacResponse',\n    },\n  ],\n  // This determines where in the sidebar the entity will appear.\n  category: 'utils',\n  // Optional. Further determines where in the sidebar category an entity will appear.\n  thumbnail: '',\n  // Optional. A section for examples. Examples may be grouped or ungrouped.\n  // A section that displays related entities in a grid of cards.\n  related: [],\n}"
+    },
+    "/utils/docs/sanitize-host.doc.ts": {
+      "filePath": "/utils/docs/sanitize-host.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'sanitizeHost',\n  description:\n    'This method makes user inputs safer by ensuring that the `host` query arguments from Shopify requests is valid.',\n  type: '',\n  isVisualComponent: false,\n  defaultExample: {\n    codeblock: {\n      tabs: [\n        {\n          code: './examples/sanitize-host.example.ts',\n          language: 'js',\n        },\n      ],\n      title: 'sanitizeHost',\n    },\n  },\n  definitions: [\n    {\n      title: 'Parameters',\n      description: '',\n      type: 'SanitizeHostParams',\n    },\n    {\n      title: 'Returns',\n      description:\n        'The `host` value if it is properly formatted, otherwise `null`.',\n      type: 'SanitizeHostReturns',\n    },\n  ],\n  category: 'utils',\n  related: [],\n}"
+    },
+    "/utils/docs/sanitize-shop.doc.ts": {
+      "filePath": "/utils/docs/sanitize-shop.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'sanitizeShop',\n  description:\n    \"This method makes user inputs safer by ensuring that a given shop value is a properly formatted Shopify shop domain.\\n\\n > Note:\\nIf you're using custom shop domains for testing, you can use the `customShopDomains` setting to add allowed domains.\",\n  type: '',\n  isVisualComponent: false,\n  defaultExample: {\n    codeblock: {\n      tabs: [\n        {\n          code: './examples/sanitize-shop.example.ts',\n          language: 'js',\n        },\n      ],\n      title: 'sanitizeShop',\n    },\n  },\n  definitions: [\n    {\n      title: 'Parameters',\n      description: '',\n      type: 'SanitizeShopParams',\n    },\n    {\n      title: 'Returns',\n      description:\n        'The `shop` value if it is a properly formatted Shopify shop domain, otherwise `null`.',\n      type: 'SanitizeShopReturns',\n    },\n  ],\n  category: 'utils',\n  related: [],\n}"
+    },
+    "/utils/docs/version-compatible.doc.ts": {
+      "filePath": "/utils/docs/version-compatible.doc.ts",
+      "name": "DataGeneratedType",
+      "value": "data: ReferenceEntityTemplateSchema = {\n  name: 'versionCompatible',\n  description:\n    \"This method determines if the given version is compatible (equal to or newer) with the configured `apiVersion` for the `shopifyApi` object. Its main use is when you want to tweak behaviour depending on your current API version, though apps won't typically need this kind of check.\",\n  type: '',\n  isVisualComponent: false,\n  defaultExample: {\n    codeblock: {\n      tabs: [\n        {\n          code: './examples/version-compatible.example.ts',\n          language: 'js',\n        },\n      ],\n      title: 'versionCompatibile',\n    },\n  },\n  definitions: [\n    {\n      title: 'Parameters',\n      description: '',\n      type: 'VersionCompatibileParams',\n    },\n    {\n      title: 'Returns',\n      description:\n        '`true` if the given version is compatible with the configured `apiVersion`.',\n      type: 'VersionCompatibleReturns',\n    },\n  ],\n  category: 'utils',\n  related: [],\n}"
+    }
+  },
+  "ConfigGeneratedType": {
+    "/__tests__/jest_projects/base.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/base.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  // or other ESM presets\n  preset: 'ts-jest/presets/default-esm',\n  testEnvironment: 'node',\n  moduleFileExtensions: ['ts', 'js', 'json'],\n  watchPathIgnorePatterns: ['./node_modules'],\n  testRegex: '.*\\\\.test\\\\.tsx?$',\n  coverageDirectory: './coverage/',\n  collectCoverage: false,\n}"
+    },
+    "/__tests__/jest_projects/adapters.cf-worker.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/adapters.cf-worker.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  ...baseConfig,\n  displayName: 'adapters:cf-worker',\n  rootDir: '../../../adapters/cf-worker',\n  testEnvironment: 'miniflare',\n}"
+    },
+    "/__tests__/jest_projects/adapters.mock.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/adapters.mock.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  ...baseConfig,\n  displayName: 'adapters:mock',\n  rootDir: '../../../adapters/mock',\n}"
+    },
+    "/__tests__/jest_projects/adapters.node.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/adapters.node.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  ...baseConfig,\n  displayName: 'adapters:node',\n  rootDir: '../../../adapters/node',\n}"
+    },
+    "/__tests__/jest_projects/eslint.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/eslint.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  runner: 'jest-runner-eslint',\n  displayName: 'lint',\n  rootDir: '../../../',\n  testMatch: ['<rootDir>/**/*.ts'],\n  watchPlugins: ['jest-runner-eslint/watch-fix'],\n  modulePathIgnorePatterns: ['<rootDir>/rest/admin/'],\n  testPathIgnorePatterns: ['.*.d.ts'],\n}"
+    },
+    "/__tests__/jest_projects/library.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/library.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  ...baseConfig,\n  displayName: 'library',\n  rootDir: '../../',\n  setupFilesAfterEnv: ['<rootDir>/setup-jest.ts'],\n}"
+    },
+    "/__tests__/jest_projects/rest_resources.jest.config.ts": {
+      "filePath": "/__tests__/jest_projects/rest_resources.jest.config.ts",
+      "name": "ConfigGeneratedType",
+      "value": "config: Config = {\n  ...baseConfig,\n  displayName: 'rest_resources',\n  rootDir: '../../../rest/admin',\n  setupFilesAfterEnv: ['<rootDir>/../../lib/setup-jest.ts'],\n}"
+    }
+  },
+  "PLAN_1GeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "PLAN_1GeneratedType",
+      "value": "PLAN_1 = 'Shopify app plan 1'"
+    }
+  },
+  "PLAN_2GeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "PLAN_2GeneratedType",
+      "value": "PLAN_2 = 'Shopify app plan 2'"
+    }
+  },
+  "ALL_PLANSGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "ALL_PLANSGeneratedType",
+      "value": "ALL_PLANS = [PLAN_1, PLAN_2]"
+    }
+  },
+  "CONFIRMATION_URLGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "CONFIRMATION_URLGeneratedType",
+      "value": "CONFIRMATION_URL = 'totally-real-url'"
+    }
+  },
+  "EMPTY_SUBSCRIPTIONSGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "EMPTY_SUBSCRIPTIONSGeneratedType",
+      "value": "EMPTY_SUBSCRIPTIONS = JSON.stringify({\n  data: {\n    currentAppInstallation: {\n      oneTimePurchases: {\n        edges: [],\n        pageInfo: {hasNextPage: false, endCursor: null},\n      },\n      activeSubscriptions: [],\n      userErrors: [],\n    },\n  },\n})"
+    }
+  },
+  "EXISTING_ONE_TIME_PAYMENTGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "EXISTING_ONE_TIME_PAYMENTGeneratedType",
+      "value": "EXISTING_ONE_TIME_PAYMENT = JSON.stringify({\n  data: {\n    currentAppInstallation: {\n      oneTimePurchases: {\n        edges: [\n          {\n            node: {name: PLAN_1, test: true, status: 'ACTIVE'},\n          },\n        ],\n        pageInfo: {hasNextPage: false, endCursor: null},\n      },\n      activeSubscriptions: [],\n    },\n  },\n})"
+    }
+  },
+  "EXISTING_ONE_TIME_PAYMENT_WITH_PAGINATIONGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "EXISTING_ONE_TIME_PAYMENT_WITH_PAGINATIONGeneratedType",
+      "value": "EXISTING_ONE_TIME_PAYMENT_WITH_PAGINATION = [\n  JSON.stringify({\n    data: {\n      currentAppInstallation: {\n        oneTimePurchases: {\n          edges: [\n            {\n              node: {name: 'some_other_name', test: true, status: 'ACTIVE'},\n            },\n          ],\n          pageInfo: {hasNextPage: true, endCursor: 'end_cursor'},\n        },\n        activeSubscriptions: [],\n      },\n    },\n  }),\n  JSON.stringify({\n    data: {\n      currentAppInstallation: {\n        oneTimePurchases: {\n          edges: [\n            {\n              node: {\n                name: PLAN_1,\n                test: true,\n                status: 'ACTIVE',\n              },\n            },\n          ],\n          pageInfo: {hasNextPage: false, endCursor: null},\n        },\n        activeSubscriptions: [],\n      },\n    },\n  }),\n]"
+    }
+  },
+  "EXISTING_INACTIVE_ONE_TIME_PAYMENTGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "EXISTING_INACTIVE_ONE_TIME_PAYMENTGeneratedType",
+      "value": "EXISTING_INACTIVE_ONE_TIME_PAYMENT = JSON.stringify({\n  data: {\n    currentAppInstallation: {\n      oneTimePurchases: {\n        edges: [\n          {\n            node: {\n              name: PLAN_1,\n              test: true,\n              status: 'PENDING',\n            },\n          },\n        ],\n        pageInfo: {hasNextPage: false, endCursor: null},\n      },\n      activeSubscriptions: [],\n    },\n  },\n})"
+    }
+  },
+  "EXISTING_SUBSCRIPTIONGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "EXISTING_SUBSCRIPTIONGeneratedType",
+      "value": "EXISTING_SUBSCRIPTION = JSON.stringify({\n  data: {\n    currentAppInstallation: {\n      oneTimePurchases: {\n        edges: [],\n        pageInfo: {hasNextPage: false, endCursor: null},\n      },\n      activeSubscriptions: [{name: PLAN_1, test: true}],\n    },\n  },\n})"
+    }
+  },
+  "PURCHASE_ONE_TIME_RESPONSEGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "PURCHASE_ONE_TIME_RESPONSEGeneratedType",
+      "value": "PURCHASE_ONE_TIME_RESPONSE = JSON.stringify({\n  data: {\n    appPurchaseOneTimeCreate: {\n      confirmationUrl: CONFIRMATION_URL,\n      userErrors: [],\n    },\n  },\n})"
+    }
+  },
+  "PURCHASE_SUBSCRIPTION_RESPONSEGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "PURCHASE_SUBSCRIPTION_RESPONSEGeneratedType",
+      "value": "PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({\n  data: {\n    appSubscriptionCreate: {\n      confirmationUrl: CONFIRMATION_URL,\n      userErrors: [],\n    },\n  },\n})"
+    }
+  },
+  "PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORSGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORSGeneratedType",
+      "value": "PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS = JSON.stringify({\n  data: {\n    appPurchaseOneTimeCreate: {\n      confirmationUrl: CONFIRMATION_URL,\n      userErrors: ['Oops, something went wrong'],\n    },\n  },\n})"
+    }
+  },
+  "PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORSGeneratedType": {
+    "/billing/__tests__/responses.ts": {
+      "filePath": "/billing/__tests__/responses.ts",
+      "name": "PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORSGeneratedType",
+      "value": "PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS = JSON.stringify({\n  data: {\n    appSubscriptionCreate: {\n      confirmationUrl: CONFIRMATION_URL,\n      userErrors: ['Oops, something went wrong'],\n    },\n  },\n})"
+    }
+  },
+  "HTTP_HANDLERGeneratedType": {
+    "/webhooks/__tests__/handlers.ts": {
+      "filePath": "/webhooks/__tests__/handlers.ts",
+      "name": "HTTP_HANDLERGeneratedType",
+      "value": "HTTP_HANDLER: HttpWebhookHandler = {\n  deliveryMethod: DeliveryMethod.Http,\n  callbackUrl: '/webhooks',\n  callback: jest.fn(),\n}"
+    }
+  },
+  "EVENT_BRIDGE_HANDLERGeneratedType": {
+    "/webhooks/__tests__/handlers.ts": {
+      "filePath": "/webhooks/__tests__/handlers.ts",
+      "name": "EVENT_BRIDGE_HANDLERGeneratedType",
+      "value": "EVENT_BRIDGE_HANDLER: EventBridgeWebhookHandler = {\n  deliveryMethod: DeliveryMethod.EventBridge,\n  arn: 'arn:test',\n}"
+    }
+  },
+  "PUB_SUB_HANDLERGeneratedType": {
+    "/webhooks/__tests__/handlers.ts": {
+      "filePath": "/webhooks/__tests__/handlers.ts",
+      "name": "PUB_SUB_HANDLERGeneratedType",
+      "value": "PUB_SUB_HANDLER: PubSubWebhookHandler = {\n  deliveryMethod: DeliveryMethod.PubSub,\n  pubSubProject: 'my-project-id',\n  pubSubTopic: 'my-topic-id',\n}"
+    }
+  },
+  "MockResponse": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "MockResponse",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/webhooks/__tests__/responses.ts",
+          "name": "[key: string]",
+          "value": "unknown"
+        }
+      ],
+      "value": "export interface MockResponse {\n  [key: string]: unknown;\n}"
+    }
+  },
+  "TEST_WEBHOOK_IDGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "TEST_WEBHOOK_IDGeneratedType",
+      "value": "TEST_WEBHOOK_ID = 'gid://shopify/WebhookSubscription/12345'"
+    }
+  },
+  "WebhookCheckEmptyResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "WebhookCheckEmptyResponseGeneratedType",
+      "value": "webhookCheckEmptyResponse = {\n  data: {\n    webhookSubscriptions: {\n      edges: [],\n      pageInfo: {\n        endCursor: null,\n        hasNextPage: false,\n      },\n    },\n  },\n}"
+    }
+  },
+  "WebhookCheckErrorResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "WebhookCheckErrorResponseGeneratedType",
+      "value": "webhookCheckErrorResponse = {\n  errors: [\n    {\n      message:\n        \"Argument 'topics' on Field 'webhookSubscriptions' has an invalid value (topic). Expected type '[WebhookSubscriptionTopic!]'.\",\n    },\n  ],\n}"
+    }
+  },
+  "WebhookCheckResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "WebhookCheckResponseGeneratedType",
+      "value": "webhookCheckResponse = {\n  data: {\n    webhookSubscriptions: {\n      edges: [\n        {\n          node: {\n            id: TEST_WEBHOOK_ID,\n            topic: 'PRODUCTS_CREATE',\n            endpoint: {\n              __typename: 'WebhookHttpEndpoint',\n              callbackUrl: 'https://test_host_name/webhooks',\n            },\n          },\n        },\n      ],\n      pageInfo: {\n        endCursor: null,\n        hasNextPage: false,\n      },\n    },\n  },\n}"
+    }
+  },
+  "WebhookCheckMultiHandlerResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "WebhookCheckMultiHandlerResponseGeneratedType",
+      "value": "webhookCheckMultiHandlerResponse = {\n  data: {\n    webhookSubscriptions: {\n      edges: [\n        {\n          node: {\n            id: TEST_WEBHOOK_ID,\n            topic: 'PRODUCTS_CREATE',\n            endpoint: {\n              __typename: 'WebhookHttpEndpoint',\n              callbackUrl: 'https://test_host_name/webhooks',\n            },\n          },\n        },\n        {\n          node: {\n            id: `${TEST_WEBHOOK_ID}-2`,\n            topic: 'PRODUCTS_UPDATE',\n            endpoint: {\n              __typename: 'WebhookHttpEndpoint',\n              callbackUrl: 'https://test_host_name/webhooks',\n            },\n          },\n        },\n      ],\n      pageInfo: {\n        endCursor: null,\n        hasNextPage: false,\n      },\n    },\n  },\n}"
+    }
+  },
+  "EventBridgeWebhookCheckResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "EventBridgeWebhookCheckResponseGeneratedType",
+      "value": "eventBridgeWebhookCheckResponse = {\n  data: {\n    webhookSubscriptions: {\n      edges: [\n        {\n          node: {\n            id: TEST_WEBHOOK_ID,\n            topic: 'PRODUCTS_CREATE',\n            endpoint: {\n              __typename: 'WebhookEventBridgeEndpoint',\n              arn: 'arn:test',\n            },\n          },\n        },\n      ],\n      pageInfo: {\n        endCursor: null,\n        hasNextPage: false,\n      },\n    },\n  },\n}"
+    }
+  },
+  "PubSubWebhookCheckResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "PubSubWebhookCheckResponseGeneratedType",
+      "value": "pubSubWebhookCheckResponse = {\n  data: {\n    webhookSubscriptions: {\n      edges: [\n        {\n          node: {\n            id: TEST_WEBHOOK_ID,\n            topic: 'PRODUCTS_CREATE',\n            endpoint: {\n              __typename: 'WebhookPubSubEndpoint',\n              pubSubProject: 'my-project-id',\n              pubSubTopic: 'my-topic-id',\n            },\n          },\n        },\n      ],\n      pageInfo: {\n        endCursor: null,\n        hasNextPage: false,\n      },\n    },\n  },\n}"
+    }
+  },
+  "SuccessResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "SuccessResponseGeneratedType",
+      "value": "successResponse = {\n  data: {\n    webhookSubscriptionCreate: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "EventBridgeSuccessResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "EventBridgeSuccessResponseGeneratedType",
+      "value": "eventBridgeSuccessResponse = {\n  data: {\n    eventBridgeWebhookSubscriptionCreate: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "PubSubSuccessResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "PubSubSuccessResponseGeneratedType",
+      "value": "pubSubSuccessResponse = {\n  data: {\n    pubSubWebhookSubscriptionCreate: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "SuccessUpdateResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "SuccessUpdateResponseGeneratedType",
+      "value": "successUpdateResponse = {\n  data: {\n    webhookSubscriptionUpdate: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "EventBridgeSuccessUpdateResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "EventBridgeSuccessUpdateResponseGeneratedType",
+      "value": "eventBridgeSuccessUpdateResponse = {\n  data: {\n    eventBridgeWebhookSubscriptionUpdate: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "PubSubSuccessUpdateResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "PubSubSuccessUpdateResponseGeneratedType",
+      "value": "pubSubSuccessUpdateResponse = {\n  data: {\n    pubSubWebhookSubscriptionUpdate: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "SuccessDeleteResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "SuccessDeleteResponseGeneratedType",
+      "value": "successDeleteResponse = {\n  data: {\n    webhookSubscriptionDelete: {\n      userErrors: [],\n    },\n  },\n}"
+    }
+  },
+  "FailResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "FailResponseGeneratedType",
+      "value": "failResponse = {\n  data: {},\n}"
+    }
+  },
+  "HttpFailResponseGeneratedType": {
+    "/webhooks/__tests__/responses.ts": {
+      "filePath": "/webhooks/__tests__/responses.ts",
+      "name": "HttpFailResponseGeneratedType",
+      "value": "httpFailResponse = {\n  data: {\n    webhookSubscriptionCreate: {\n      userErrors: ['this is an error'],\n    },\n  },\n}"
+    }
+  },
+  "GetTestExpressAppGeneratedType": {
+    "/webhooks/__tests__/utils.ts": {
+      "filePath": "/webhooks/__tests__/utils.ts",
+      "name": "GetTestExpressAppGeneratedType",
+      "params": [],
+      "returns": {
+        "filePath": "/webhooks/__tests__/utils.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function getTestExpressApp() {\n  const parseRawBody = (req: any, _res: any, next: any) => {\n    req.setEncoding('utf8');\n    req.rawBody = '';\n    req.on('data', (chunk: any) => {\n      req.rawBody += chunk;\n    });\n    req.on('end', () => {\n      next();\n    });\n  };\n\n  const app = express();\n  app.use(parseRawBody);\n  return app;\n}"
+    }
+  },
+  "HeadersGeneratedType": {
+    "/webhooks/__tests__/utils.ts": {
+      "filePath": "/webhooks/__tests__/utils.ts",
+      "name": "HeadersGeneratedType",
+      "params": [
+        {
+          "name": "input1",
+          "description": "",
+          "value": "{ apiVersion?: string; domain?: string; hmac?: string; topic?: string; webhookId?: string; lowercase?: boolean; }",
+          "isOptional": true,
+          "defaultValue": "{}",
+          "filePath": "/webhooks/__tests__/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/__tests__/utils.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function headers({\n  apiVersion = '2023-01',\n  domain = 'shop1.myshopify.io',\n  hmac = 'fake',\n  topic = 'products/create',\n  webhookId = '123456789',\n  lowercase = false,\n}: {\n  apiVersion?: string;\n  domain?: string;\n  hmac?: string;\n  topic?: string;\n  webhookId?: string;\n  lowercase?: boolean;\n} = {}) {\n  return {\n    [lowercase\n      ? ShopifyHeader.ApiVersion.toLowerCase()\n      : ShopifyHeader.ApiVersion]: apiVersion,\n    [lowercase ? ShopifyHeader.Domain.toLowerCase() : ShopifyHeader.Domain]:\n      domain,\n    [lowercase ? ShopifyHeader.Hmac.toLowerCase() : ShopifyHeader.Hmac]: hmac,\n    [lowercase ? ShopifyHeader.Topic.toLowerCase() : ShopifyHeader.Topic]:\n      topic,\n    [lowercase\n      ? ShopifyHeader.WebhookId.toLowerCase()\n      : ShopifyHeader.WebhookId]: webhookId,\n  };\n}"
+    }
+  },
+  "HmacGeneratedType": {
+    "/webhooks/__tests__/utils.ts": {
+      "filePath": "/webhooks/__tests__/utils.ts",
+      "name": "HmacGeneratedType",
+      "params": [
+        {
+          "name": "secret",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/__tests__/utils.ts"
+        },
+        {
+          "name": "body",
+          "description": "",
+          "value": "string",
+          "filePath": "/webhooks/__tests__/utils.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/webhooks/__tests__/utils.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "export function hmac(secret: string, body: string) {\n  return crypto.createHmac('sha256', secret).update(body).digest('base64');\n}"
+    }
+  },
+  "BillingMiddlewareGeneratedType": {
+    "/billing/docs/examples/check.example.ts": {
+      "filePath": "/billing/docs/examples/check.example.ts",
+      "name": "BillingMiddlewareGeneratedType",
+      "params": [
+        {
+          "name": "req",
+          "description": "",
+          "value": "any",
+          "filePath": "/billing/docs/examples/check.example.ts"
+        },
+        {
+          "name": "res",
+          "description": "",
+          "value": "any",
+          "filePath": "/billing/docs/examples/check.example.ts"
+        },
+        {
+          "name": "next",
+          "description": "",
+          "value": "any",
+          "filePath": "/billing/docs/examples/check.example.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/billing/docs/examples/check.example.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "async function billingMiddleware(req, res, next) {\n  const sessionId = shopify.session.getCurrentId({\n    isOnline: true,\n    rawRequest: req,\n    rawResponse: res,\n  });\n\n  // use sessionId to retrieve session from app's session storage\n  // In this example, getSessionFromStorage() must be provided by app\n  const session = await getSessionFromStorage(sessionId);\n\n  const hasPayment = await shopify.billing.check({\n    session,\n    plans: ['My billing plan'],\n    isTest: true,\n  });\n\n  if (hasPayment) {\n    next();\n  } else {\n    // Either request payment now (if single plan) or redirect to plan selection page (if multiple plans available), e.g.\n    const confirmationUrl = await shopify.billing.request({\n      session,\n      plan: 'My billing plan',\n      isTest: true,\n    });\n\n    res.redirect(confirmationUrl);\n  }\n}"
+    }
+  },
+  "MyWebhookHandlerGeneratedType": {
+    "/session/docs/examples/get-offline-id.example.ts": {
+      "filePath": "/session/docs/examples/get-offline-id.example.ts",
+      "name": "MyWebhookHandlerGeneratedType",
+      "params": [
+        {
+          "name": "topic",
+          "description": "",
+          "value": "any",
+          "filePath": "/session/docs/examples/get-offline-id.example.ts"
+        },
+        {
+          "name": "shop",
+          "description": "",
+          "value": "any",
+          "filePath": "/session/docs/examples/get-offline-id.example.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/session/docs/examples/get-offline-id.example.ts",
+        "description": "",
+        "name": "",
+        "value": ""
+      },
+      "value": "async function myWebhookHandler(topic, shop) {\n  const offlineSessionId = await shopify.session.getOfflineId({shop});\n\n  // use sessionId to retrieve session from app's session storage\n  // getSessionFromStorage() must be provided by application\n  const session = await getSessionFromStorage(offlineSessionId);\n\n  // Perform webhook actions\n}"
+    }
+  },
+  "HandleFetchGeneratedType": {
+    "/auth/oauth/docs/examples/begin.cloudflare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/begin.cloudflare.example.ts",
+      "name": "HandleFetchGeneratedType",
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "/auth/oauth/docs/examples/begin.cloudflare.example.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/docs/examples/begin.cloudflare.example.ts",
+        "description": "",
+        "name": "Promise<Response>",
+        "value": "Promise<Response>"
+      },
+      "value": "async function handleFetch(request: Request): Promise<Response> {\n  const {searchParams} = new URL(request.url);\n\n  // The library will return a Response object\n  return shopify.auth.begin({\n    shop: shopify.utils.sanitizeShop(searchParams.get('shop'), true),\n    callbackPath: '/auth/callback',\n    isOnline: false,\n    rawRequest: request,\n  });\n}"
+    },
+    "/auth/oauth/docs/examples/callback.cloudflare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/callback.cloudflare.example.ts",
+      "name": "HandleFetchGeneratedType",
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "/auth/oauth/docs/examples/callback.cloudflare.example.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "/auth/oauth/docs/examples/callback.cloudflare.example.ts",
+        "description": "",
+        "name": "Promise<Response>",
+        "value": "Promise<Response>"
+      },
+      "value": "async function handleFetch(request: Request): Promise<Response> {\n  const callback = await shopify.auth.callback<Headers>({\n    rawRequest: request,\n  });\n\n  // You can now use callback.session to make API requests\n\n  // The callback returns some HTTP headers, but you can redirect to any route here\n  return new Response('', {\n    status: 302,\n    // Headers are of type [string, string][]\n    headers: [...callback.headers, ['Location', '/my-apps-entry-page']],\n  });\n}"
+    }
+  },
+  "StateGeneratedType": {
+    "/auth/oauth/docs/examples/nonce.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/nonce.example.ts",
+      "name": "StateGeneratedType",
+      "value": "state = shopify.auth.nonce()"
+    }
+  },
+  "StringArray1GeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "StringArray1GeneratedType",
+      "value": "stringArray1 = ['alice', 'bob', 'charlie']"
+    }
+  },
+  "StringArray2GeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "StringArray2GeneratedType",
+      "value": "stringArray2 = ['alice', 'bob', 'charlie']"
+    }
+  },
+  "StringArrayResultGeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "StringArrayResultGeneratedType",
+      "value": "stringArrayResult = shopify.auth.safeCompare(stringArray1, stringArray2)"
+    }
+  },
+  "Array1GeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "Array1GeneratedType",
+      "value": "array1 = ['one fish', 'two fish']"
+    }
+  },
+  "Array2GeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "Array2GeneratedType",
+      "value": "array2 = ['red fish', 'blue fish']"
+    }
+  },
+  "ArrayResultGeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "ArrayResultGeneratedType",
+      "value": "arrayResult = shopify.auth.safeCompare(array1, array2)"
+    }
+  },
+  "Arg1GeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "Arg1GeneratedType",
+      "value": "arg1 = 'hello'"
+    }
+  },
+  "Arg2GeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "Arg2GeneratedType",
+      "value": "arg2 = ['world']"
+    }
+  },
+  "ArgResultGeneratedType": {
+    "/auth/oauth/docs/examples/safe-compare.example.ts": {
+      "filePath": "/auth/oauth/docs/examples/safe-compare.example.ts",
+      "name": "ArgResultGeneratedType",
+      "value": "argResult = shopify.auth.safeCompare(arg1, arg2)"
+    }
+  },
+  "IsValidGeneratedType": {
+    "/utils/docs/examples/hmac-validator.example.ts": {
+      "filePath": "/utils/docs/examples/hmac-validator.example.ts",
+      "name": "IsValidGeneratedType",
+      "value": "isValid = await shopify.utils.validateHmac(req.query)"
+    }
+  },
+  "HostGeneratedType": {
+    "/utils/docs/examples/sanitize-host.example.ts": {
+      "filePath": "/utils/docs/examples/sanitize-host.example.ts",
+      "name": "HostGeneratedType",
+      "value": "host = shopify.utils.sanitizeHost(req.query.host, true)"
+    }
+  },
+  "ShopGeneratedType": {
+    "/utils/docs/examples/sanitize-shop.example.ts": {
+      "filePath": "/utils/docs/examples/sanitize-shop.example.ts",
+      "name": "ShopGeneratedType",
+      "value": "shop = shopify.utils.sanitizeShop(req.query.shop, true)"
+    }
+  },
+  "FakeResourceWithCustomPrefixFindArgs": {
+    "/clients/rest/__tests__/resources/fake-resource-with-custom-prefix.ts": {
+      "filePath": "/clients/rest/__tests__/resources/fake-resource-with-custom-prefix.ts",
+      "name": "FakeResourceWithCustomPrefixFindArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource-with-custom-prefix.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource-with-custom-prefix.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "string | number",
+          "description": ""
+        }
+      ],
+      "value": "interface FakeResourceWithCustomPrefixFindArgs {\n  session: Session;\n  id: string | number;\n}"
+    }
+  },
+  "FakeResourceFindArgs": {
+    "/clients/rest/__tests__/resources/fake-resource.ts": {
+      "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+      "name": "FakeResourceFindArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "param",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "other_resource_id",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface FakeResourceFindArgs {\n  param?: string | null;\n  session: Session;\n  id: number;\n  other_resource_id?: number | null;\n}"
+    }
+  },
+  "FakeResourceAllArgs": {
+    "/clients/rest/__tests__/resources/fake-resource.ts": {
+      "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+      "name": "FakeResourceAllArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "param",
+          "value": "string",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        }
+      ],
+      "value": "interface FakeResourceAllArgs {\n  param?: string | null;\n  session: Session;\n}"
+    }
+  },
+  "FakeResourceCustomArgs": {
+    "/clients/rest/__tests__/resources/fake-resource.ts": {
+      "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+      "name": "FakeResourceCustomArgs",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "id",
+          "value": "number",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/fake-resource.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "other_resource_id",
+          "value": "number",
+          "description": ""
+        }
+      ],
+      "value": "interface FakeResourceCustomArgs {\n  session: Session;\n  id: number;\n  other_resource_id: number;\n}"
+    }
+  },
+  "TestRestResources": {
+    "/clients/rest/__tests__/resources/test-resources.ts": {
+      "filePath": "/clients/rest/__tests__/resources/test-resources.ts",
+      "name": "TestRestResources",
+      "description": "",
+      "members": [
+        {
+          "filePath": "/clients/rest/__tests__/resources/test-resources.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "FakeResource",
+          "value": "typeof FakeResource",
+          "description": ""
+        },
+        {
+          "filePath": "/clients/rest/__tests__/resources/test-resources.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "FakeResourceWithCustomPrefix",
+          "value": "typeof FakeResourceWithCustomPrefix",
+          "description": ""
+        }
+      ],
+      "value": "interface TestRestResources extends ShopifyRestResources {\n  FakeResource: typeof FakeResource;\n  FakeResourceWithCustomPrefix: typeof FakeResourceWithCustomPrefix;\n}"
+    }
+  },
+  "RestResourcesGeneratedType": {
+    "/clients/rest/__tests__/resources/test-resources.ts": {
+      "filePath": "/clients/rest/__tests__/resources/test-resources.ts",
+      "name": "RestResourcesGeneratedType",
+      "value": "restResources: TestRestResources = {\n  FakeResource,\n  FakeResourceWithCustomPrefix,\n}"
+    }
+  }
+}

--- a/lib/clients/graphql/__tests__/graphql_client.test.ts
+++ b/lib/clients/graphql/__tests__/graphql_client.test.ts
@@ -195,6 +195,11 @@ describe('GraphQL client', () => {
       }`,
     };
 
+    const expectedHeaders = {
+      'Content-Type': 'application/graphql',
+      'X-Shopify-Access-Token': 'any_access_token',
+    };
+
     const errorResponse = {
       data: null,
       errors: [
@@ -220,6 +225,7 @@ describe('GraphQL client', () => {
           },
         },
       },
+      headers: expectedHeaders,
     };
 
     queueMockResponse(JSON.stringify(errorResponse));
@@ -228,6 +234,7 @@ describe('GraphQL client', () => {
       new ShopifyErrors.GraphqlQueryError({
         message: 'GraphQL query returned errors',
         response: errorResponse,
+        headers: expectedHeaders,
       }),
     );
 

--- a/lib/clients/graphql/graphql_client.ts
+++ b/lib/clients/graphql/graphql_client.ts
@@ -82,6 +82,7 @@ export class GraphqlClient {
       throw new ShopifyErrors.GraphqlQueryError({
         message: 'GraphQL query returned errors',
         response: result.body as unknown as {[key: string]: unknown},
+        headers: result.headers,
       });
     }
     return result;

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -69,16 +69,20 @@ export class HttpThrottlingError extends HttpRetriableError {
 export class RestResourceError extends ShopifyError {}
 export class GraphqlQueryError extends ShopifyError {
   readonly response: {[key: string]: unknown};
+  headers?: {[key: string]: unknown};
 
   public constructor({
     message,
     response,
+    headers,
   }: {
     message: string;
     response: {[key: string]: unknown};
+    headers?: {[key: string]: unknown};
   }) {
     super(message);
     this.response = response;
+    this.headers = headers;
   }
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #553 (https://github.com/Shopify/shopify-api-js/issues/553)

### WHAT is this pull request doing?

When a `GraphqlQueryError` is raised we were not adding in the error the response's headers. Those can be useful to understand the error. So this is now rectified

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
