### PR TITLE
Force / path on session cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Patch] Force `/` path on session cookie [#658](https://github.com/Shopify/shopify-api-js/pull/658)
 - [Patch] Don't ignore previous headers when beginning OAuth [#652](https://github.com/Shopify/shopify-api-js/pull/652)
 - [Patch] Export missing client types from package [#648](https://github.com/Shopify/shopify-api-js/pull/648)
 - [Patch] Add an info-level log of API library version and runtime environment string during initialization, to aid in troubleshooting [650](https://github.com/Shopify/shopify-api-js/pull/650)

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -179,6 +179,7 @@ export function callback(config: ConfigInterface) {
         expires: session.expires,
         sameSite: 'lax',
         secure: true,
+        path: '/',
       });
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

After doing OAuth on a non-embedded app, we set a cookie with the Shopify session id, but it seems that Chrome is defaulting the `path` for that cookie to `/api/auth` in the app template (i.e. the path that initiated the request).

### WHAT is this pull request doing?

Forcing the path on the session cookie to be `/`, which enables any request in the app to use it.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
