### PR TITLE
Fix logger call on different API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Patch] Fix logger call on different API versions [#664](https://github.com/Shopify/shopify-api-js/pull/664)
+
 ## [6.1.0] - 2023-01-05
 
 - [Minor] Allow api version overrides [#660](https://github.com/Shopify/shopify-api-js/pull/660)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- [Patch] Fix logger call on different API versions [#664](https://github.com/Shopify/shopify-api-js/pull/664)
+- [Patch] Improve logger call on different API versions [#664](https://github.com/Shopify/shopify-api-js/pull/664)
 
 ## [6.1.0] - 2023-01-05
 

--- a/lib/clients/rest/__tests__/resources/load-rest-resources.test.ts
+++ b/lib/clients/rest/__tests__/resources/load-rest-resources.test.ts
@@ -25,7 +25,7 @@ describe('Load REST resources', () => {
     expect(shopify.config.logger.log).toHaveBeenCalledWith(
       LogSeverity.Warning,
       expect.stringContaining(
-        `Current API version '2020-01' does not match resource API version '${LATEST_API_VERSION}'`,
+        `Loading REST resources for API version ${LATEST_API_VERSION}, which doesn't match the default 2020-01`,
       ),
     );
 

--- a/lib/clients/rest/__tests__/resources/load-rest-resources.test.ts
+++ b/lib/clients/rest/__tests__/resources/load-rest-resources.test.ts
@@ -24,7 +24,9 @@ describe('Load REST resources', () => {
 
     expect(shopify.config.logger.log).toHaveBeenCalledWith(
       LogSeverity.Warning,
-      `Current API version '2020-01' does not match resource API version '${LATEST_API_VERSION}'`,
+      expect.stringContaining(
+        `Current API version '2020-01' does not match resource API version '${LATEST_API_VERSION}'`,
+      ),
     );
 
     expect(shopify.rest).toHaveProperty('FakeResource');

--- a/rest/load-rest-resources.ts
+++ b/rest/load-rest-resources.ts
@@ -1,6 +1,6 @@
-import {LogSeverity} from '../lib/types';
 import {ConfigInterface} from '../lib/base-types';
 import {RestClient} from '../lib/clients/rest/rest_client';
+import {logger} from '../lib/logger';
 
 import {ShopifyRestResources} from './types';
 
@@ -17,8 +17,7 @@ export function loadRestResources({
 }: LoadRestResourcesParams): ShopifyRestResources {
   const firstResource = Object.keys(resources)[0];
   if (config.apiVersion !== resources[firstResource].API_VERSION) {
-    config.logger.log(
-      LogSeverity.Warning,
+    logger(config).warning(
       `Current API version '${config.apiVersion}' does not match ` +
         `resource API version '${resources[firstResource].API_VERSION}'`,
     );

--- a/rest/load-rest-resources.ts
+++ b/rest/load-rest-resources.ts
@@ -18,8 +18,7 @@ export function loadRestResources({
   const firstResource = Object.keys(resources)[0];
   if (config.apiVersion !== resources[firstResource].API_VERSION) {
     logger(config).warning(
-      `Current API version '${config.apiVersion}' does not match ` +
-        `resource API version '${resources[firstResource].API_VERSION}'`,
+      `Loading REST resources for API version ${resources[firstResource].API_VERSION}, which doesn't match the default ${config.apiVersion}`,
     );
   }
 


### PR DESCRIPTION
I made a small mistake in my latest change, this just fixes that - we should be calling the `logger` utility, rather than directly patching through to `config.logger.log`.

The log wording was also not great, so I improved it a little bit.