### PR TITLE
Add Hmac timestamp validation on OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- [Minor] Validate HMAC timestgamp during OAuth [#671](https://github.com/Shopify/shopify-api-js/pull/671)
 - [Patch] Improve logger call on different API versions [#664](https://github.com/Shopify/shopify-api-js/pull/664)
 
 ## [6.1.0] - 2023-01-05

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -1,7 +1,10 @@
 import querystring from 'querystring';
 
 import * as ShopifyErrors from '../../../error';
-import {generateLocalHmac} from '../../../utils/hmac-validator';
+import {
+  generateLocalHmac,
+  getCurrentTimeInSec,
+} from '../../../utils/hmac-validator';
 import {JwtPayload} from '../../../session/types';
 import {nonce} from '../nonce';
 import {
@@ -197,7 +200,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     testCallbackQuery.hmac = 'definitely the wrong hmac';
@@ -223,7 +226,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: 'incorrect state',
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(
@@ -252,7 +255,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(
@@ -295,7 +298,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(
@@ -371,7 +374,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(
@@ -455,7 +458,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(
@@ -517,7 +520,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(
@@ -564,7 +567,7 @@ describe('callback', () => {
     const testCallbackQuery: QueryMock = {
       shop,
       state: VALID_NONCE,
-      timestamp: Number(new Date()).toString(),
+      timestamp: getCurrentTimeInSec().toString(),
       code: 'some random auth code',
     };
     const expectedHmac = await generateLocalHmac(shopify.config)(

--- a/lib/utils/__tests__/hmac-validator.test.ts
+++ b/lib/utils/__tests__/hmac-validator.test.ts
@@ -4,15 +4,15 @@ import {shopify} from '../../__tests__/test-helper';
 import {AuthQuery} from '../../auth/oauth/types';
 import * as ShopifyErrors from '../../error';
 
-test('correctly validates query objects', async () => {
+test('correctly validates query objects and timestamp', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const queryString =
-    'code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=a+number+as+a+string';
+  const submittedTimestamp = String(Date.now() - 5000);
+  const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',
     shop: 'the shop URL',
     state: 'some nonce passed from auth',
-    timestamp: 'a number as a string',
+    timestamp: submittedTimestamp,
   };
 
   const localHmac = crypto
@@ -73,5 +73,31 @@ test('queries with extra keys are included in hmac querystring', async () => {
 
   await expect(shopify.utils.validateHmac(queryObjectWithHmac)).resolves.toBe(
     true,
+  );
+});
+
+test('hmac with timestamp older than 10 seconds throws InvalidHmacError', async () => {
+  shopify.config.apiSecretKey = 'my super secret key';
+  const submittedTimestamp = String(Date.now() - 11000);
+  const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
+  const queryObjectWithoutHmac = {
+    code: 'some code goes here',
+    shop: 'the shop URL',
+    state: 'some nonce passed from auth',
+    timestamp: submittedTimestamp,
+  };
+
+  const localHmac = crypto
+    .createHmac('sha256', shopify.config.apiSecretKey)
+    .update(queryString)
+    .digest('hex');
+
+  const testQuery: AuthQuery = Object.assign(queryObjectWithoutHmac, {
+    hmac: localHmac,
+  });
+
+  const validateHmac = shopify.utils.validateHmac;
+  await expect(validateHmac(testQuery)).rejects.toBeInstanceOf(
+    ShopifyErrors.InvalidHmacError,
   );
 });

--- a/lib/utils/__tests__/hmac-validator.test.ts
+++ b/lib/utils/__tests__/hmac-validator.test.ts
@@ -3,10 +3,11 @@ import crypto from 'crypto';
 import {shopify} from '../../__tests__/test-helper';
 import {AuthQuery} from '../../auth/oauth/types';
 import * as ShopifyErrors from '../../error';
+import {getCurrentTimeInSec} from '../hmac-validator';
 
 test('correctly validates query objects and timestamp', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const submittedTimestamp = String(Date.now() - 5000);
+  const submittedTimestamp = String(getCurrentTimeInSec() - 5);
   const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',
@@ -78,7 +79,7 @@ test('queries with extra keys are included in hmac querystring', async () => {
 
 test('hmac with timestamp older than 10 seconds throws InvalidHmacError', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const submittedTimestamp = String(Date.now() - 11000);
+  const submittedTimestamp = String(getCurrentTimeInSec() - 11);
   const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',
@@ -104,7 +105,7 @@ test('hmac with timestamp older than 10 seconds throws InvalidHmacError', async 
 
 test('hmac with timestamp more than 10 seconds in the future throws InvalidHmacError', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const submittedTimestamp = String(Date.now() + 11000);
+  const submittedTimestamp = String(getCurrentTimeInSec() + 11);
   const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',

--- a/lib/utils/__tests__/hmac-validator.test.ts
+++ b/lib/utils/__tests__/hmac-validator.test.ts
@@ -7,7 +7,7 @@ import {getCurrentTimeInSec} from '../hmac-validator';
 
 test('correctly validates query objects and timestamp', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const submittedTimestamp = String(getCurrentTimeInSec() - 5);
+  const submittedTimestamp = String(getCurrentTimeInSec() - 60);
   const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',
@@ -79,7 +79,7 @@ test('queries with extra keys are included in hmac querystring', async () => {
 
 test('hmac with timestamp older than 10 seconds throws InvalidHmacError', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const submittedTimestamp = String(getCurrentTimeInSec() - 11);
+  const submittedTimestamp = String(getCurrentTimeInSec() - 91);
   const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',
@@ -105,7 +105,7 @@ test('hmac with timestamp older than 10 seconds throws InvalidHmacError', async 
 
 test('hmac with timestamp more than 10 seconds in the future throws InvalidHmacError', async () => {
   shopify.config.apiSecretKey = 'my super secret key';
-  const submittedTimestamp = String(getCurrentTimeInSec() + 11);
+  const submittedTimestamp = String(getCurrentTimeInSec() + 91);
   const queryString = `code=some+code+goes+here&shop=the+shop+URL&state=some+nonce+passed+from+auth&timestamp=${submittedTimestamp}`;
   const queryObjectWithoutHmac = {
     code: 'some code goes here',

--- a/lib/utils/hmac-validator.ts
+++ b/lib/utils/hmac-validator.ts
@@ -7,6 +7,8 @@ import {safeCompare} from '../auth/oauth/safe-compare';
 
 import ProcessedQuery from './processed-query';
 
+const HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_MS = 10000;
+
 function stringifyQuery(query: AuthQuery): string {
   const processedQuery = new ProcessedQuery();
   Object.keys(query)
@@ -31,9 +33,23 @@ export function validateHmac(config: ConfigInterface) {
         'Query does not contain an HMAC value.',
       );
     }
+
+    validateHmacTimestamp(query);
+
     const {hmac} = query;
     const localHmac = await generateLocalHmac(config)(query);
 
     return safeCompare(hmac as string, localHmac);
   };
+}
+
+function validateHmacTimestamp(query: AuthQuery) {
+  if (
+    Date.now() - Number(query.timestamp) >
+    HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_MS
+  ) {
+    throw new ShopifyErrors.InvalidHmacError(
+      'HMAC timestamp is outside of the tolerance range',
+    );
+  }
 }

--- a/lib/utils/hmac-validator.ts
+++ b/lib/utils/hmac-validator.ts
@@ -7,7 +7,7 @@ import {safeCompare} from '../auth/oauth/safe-compare';
 
 import ProcessedQuery from './processed-query';
 
-const HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC = 10;
+const HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC = 90;
 
 function stringifyQuery(query: AuthQuery): string {
   const processedQuery = new ProcessedQuery();

--- a/lib/utils/hmac-validator.ts
+++ b/lib/utils/hmac-validator.ts
@@ -7,7 +7,7 @@ import {safeCompare} from '../auth/oauth/safe-compare';
 
 import ProcessedQuery from './processed-query';
 
-const HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_MS = 10000;
+const HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC = 10;
 
 function stringifyQuery(query: AuthQuery): string {
   const processedQuery = new ProcessedQuery();
@@ -43,10 +43,14 @@ export function validateHmac(config: ConfigInterface) {
   };
 }
 
+export function getCurrentTimeInSec() {
+  return Math.trunc(Date.now() / 1000);
+}
+
 function validateHmacTimestamp(query: AuthQuery) {
   if (
-    Math.abs(Date.now() - Number(query.timestamp)) >
-    HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_MS
+    Math.abs(getCurrentTimeInSec() - Number(query.timestamp)) >
+    HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC
   ) {
     throw new ShopifyErrors.InvalidHmacError(
       'HMAC timestamp is outside of the tolerance range',

--- a/lib/utils/hmac-validator.ts
+++ b/lib/utils/hmac-validator.ts
@@ -45,7 +45,7 @@ export function validateHmac(config: ConfigInterface) {
 
 function validateHmacTimestamp(query: AuthQuery) {
   if (
-    Date.now() - Number(query.timestamp) >
+    Math.abs(Date.now() - Number(query.timestamp)) >
     HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_MS
   ) {
     throw new ShopifyErrors.InvalidHmacError(


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #570 https://github.com/Shopify/shopify-api-js/issues/570

During the OAuth flow we receive an HMAC that has been computer over URL parameters. One of them is a timestamp. This timestamp wasn't validated therefore allowing potential replay attack to occur.

### WHAT is this pull request doing?
This PR add timestamp validation to ensure the submitted timestamp is within a reasonable windows in the past or in the future
The tolerance should be big enough that it doesn't break anything. However if servers are widely desynchronized then this may be an issue, arguably something that 3p should fix. But does it means this should be a breaking change on our end?

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
