### PR TITLE
Enable markdown links check for PR too

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,6 +1,6 @@
 name: Check Markdown links
 
-on: push
+on: [push, pull_request]
 
 jobs:
   markdown-link-check:


### PR DESCRIPTION

### WHY are these changes introduced?

Github workflow configuration bug: the markdown links check wasn't triggered on pull requests

### WHAT is this pull request doing?

Update the `markdown_link_check.yml` file so that this checks can run on PR as well.

## Type of change

n/a

## Checklist

n/a
