### PR TITLE
Add REST resource pagination documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 - [Minor] Validate HMAC timestamp during OAuth [#671](https://github.com/Shopify/shopify-api-js/pull/671)
 - [Patch] Improve logger call on different API versions [#664](https://github.com/Shopify/shopify-api-js/pull/664)
 - [Patch] Prevent leakage of session object with REST resources [#690](https://github.com/Shopify/shopify-api-js/pull/690)
+- [Patch] Improve typing of `PREV_PAGE_INFO` and `NEXT_PAGE_INFO` for REST resources [#701](https://github.com/Shopify/shopify-api-js/pull/701)
 
 ## [6.1.0] - 2023-01-05
 

--- a/docs/guides/rest-resources.md
+++ b/docs/guides/rest-resources.md
@@ -104,4 +104,30 @@ const shopify = shopifyApi({
 This will automatically load all REST resources onto `shopify.rest`, as per the example above.
 From this point, you can start using the resources to interact with the API.
 
+## Paginated requests
+
+Shopify's REST API supports [cursor-based pagination](https://shopify.dev/api/usage/pagination-rest), to limit the amount of data sent to an app on a single request.
+
+Each request will return the information required for an app to request the previous / next set of items.
+
+For REST resources, the class will contain the information necessary to make those requests in the `NEXT_PAGE_INFO` and `PREV_PAGE_INFO` properties.
+These values will always reflect the last request made with that class.
+
+Here is an example for fetching more than one set of products from the API:
+
+```ts
+do {
+  const pageProducts = await shopify.rest.Product.all({
+    ...shopify.rest.Product.NEXT_PAGE_INFO?.query,
+    session,
+    status: 'active',
+  });
+
+  // ... use pageProducts
+} while (shopify.rest.Product.NEXT_PAGE_INFO);
+```
+
+> **Note**: these properties are not thread-safe because they're stored statically in the class.
+> If you are using this feature to send requests in parallel, you can store the `query` property in a thread-safe way, since it's a plain JavaScript object.
+
 [Back to guide index](../../README.md#guides)

--- a/lib/clients/rest/__tests__/resources/base.test.ts
+++ b/lib/clients/rest/__tests__/resources/base.test.ts
@@ -55,7 +55,7 @@ describe('Base REST resource', () => {
     const got = await shopify.rest.FakeResource.find({
       id: 1,
       session,
-      params: {param: 'value'},
+      param: 'value',
     });
 
     expect([got!.id, got!.attribute]).toEqual([1, 'attribute']);
@@ -415,15 +415,15 @@ describe('Base REST resource', () => {
     expect(shopify.rest.FakeResource.PREV_PAGE_INFO).toBeUndefined();
 
     await shopify.rest.FakeResource.all({
+      ...shopify.rest.FakeResource.NEXT_PAGE_INFO?.query,
       session,
-      params: shopify.rest.FakeResource.NEXT_PAGE_INFO?.query,
     });
     expect(shopify.rest.FakeResource.NEXT_PAGE_INFO).toBeUndefined();
     expect(shopify.rest.FakeResource.PREV_PAGE_INFO).not.toBeUndefined();
 
     await shopify.rest.FakeResource.all({
+      ...shopify.rest.FakeResource.PREV_PAGE_INFO?.query,
       session,
-      params: shopify.rest.FakeResource.PREV_PAGE_INFO?.query,
     });
     expect(shopify.rest.FakeResource.NEXT_PAGE_INFO).toBeUndefined();
     expect(shopify.rest.FakeResource.PREV_PAGE_INFO).toBeUndefined();

--- a/lib/clients/rest/__tests__/resources/fake-resource.ts
+++ b/lib/clients/rest/__tests__/resources/fake-resource.ts
@@ -1,17 +1,17 @@
 import {Base} from '../../../../../rest/base';
-import {ParamSet, ResourcePath} from '../../../../../rest/types';
+import {ResourcePath} from '../../../../../rest/types';
 import {Session} from '../../../../session/session';
 import {LATEST_API_VERSION} from '../../../../types';
 
 interface FakeResourceFindArgs {
-  params?: ParamSet;
+  param?: string | null;
   session: Session;
   id: number;
   other_resource_id?: number | null;
 }
 
 interface FakeResourceAllArgs {
-  params?: ParamSet;
+  param?: string | null;
   session: Session;
 }
 
@@ -89,27 +89,28 @@ export class FakeResource extends Base {
 
   public static async find({
     session,
-    params,
     id,
     other_resource_id = null,
+    param = null,
     ...otherArgs
   }: FakeResourceFindArgs): Promise<FakeResource | null> {
     const result = await this.baseFind<FakeResource>({
       session,
       urlIds: {id, other_resource_id},
-      params: {...params, ...otherArgs},
+      params: {param, ...otherArgs},
     });
     return result ? result[0] : null;
   }
 
   public static async all({
     session,
-    params,
+    param = null,
+    ...otherArgs
   }: FakeResourceAllArgs): Promise<FakeResource[]> {
     return this.baseFind<FakeResource>({
       session,
-      params,
       urlIds: {},
+      params: {param, ...otherArgs},
     });
   }
 

--- a/lib/clients/rest/rest_client.ts
+++ b/lib/clients/rest/rest_client.ts
@@ -1,13 +1,18 @@
 import {getHeader} from '../../../runtime/http';
 import {ApiVersion, ShopifyHeader} from '../../types';
 import {ConfigInterface} from '../../base-types';
-import {RequestParams, GetRequestParams} from '../http_client/types';
+import {RequestParams} from '../http_client/types';
 import * as ShopifyErrors from '../../error';
 import {HttpClient} from '../http_client/http_client';
 import {Session} from '../../session/session';
 import {logger} from '../../logger';
 
-import {RestRequestReturn, PageInfo, RestClientParams} from './types';
+import {
+  RestRequestReturn,
+  PageInfo,
+  RestClientParams,
+  PageInfoParams,
+} from './types';
 
 export interface RestClientClassParams {
   config: ConfigInterface;
@@ -120,7 +125,7 @@ export class RestClient extends HttpClient {
     return this.constructor as typeof RestClient;
   }
 
-  private buildRequestParams(newPageUrl: string): GetRequestParams {
+  private buildRequestParams(newPageUrl: string): PageInfoParams {
     const pattern = `^/admin/api/[^/]+/(.*).json$`;
 
     const url = new URL(newPageUrl);

--- a/lib/clients/rest/types.ts
+++ b/lib/clients/rest/types.ts
@@ -1,14 +1,19 @@
 import {ApiVersion} from '../../types';
 import {Session} from '../../session/session';
-import {RequestReturn, GetRequestParams} from '../http_client/types';
+import {RequestReturn, QueryParams} from '../http_client/types';
+
+export interface PageInfoParams {
+  path: string;
+  query: {[key: string]: QueryParams};
+}
 
 export interface PageInfo {
   limit: string;
   fields?: string[];
   previousPageUrl?: string;
   nextPageUrl?: string;
-  prevPage?: GetRequestParams;
-  nextPage?: GetRequestParams;
+  prevPage?: PageInfoParams;
+  nextPage?: PageInfoParams;
 }
 
 export type RestRequestReturn<T = unknown> = RequestReturn<T> & {

--- a/rest/base.ts
+++ b/rest/base.ts
@@ -1,7 +1,7 @@
 import {RestResourceError} from '../lib/error';
 import {Session} from '../lib/session/session';
-import {RestRequestReturn} from '../lib/clients/rest/types';
-import {DataType, GetRequestParams} from '../lib/clients/http_client/types';
+import {PageInfoParams, RestRequestReturn} from '../lib/clients/rest/types';
+import {DataType} from '../lib/clients/http_client/types';
 import {RestClient} from '../lib/clients/rest/rest_client';
 import {ApiVersion} from '../lib/types';
 import {ConfigInterface} from '../lib/base-types';
@@ -46,8 +46,8 @@ export class Base {
   // For instance attributes
   [key: string]: any;
 
-  public static NEXT_PAGE_INFO: GetRequestParams | undefined;
-  public static PREV_PAGE_INFO: GetRequestParams | undefined;
+  public static NEXT_PAGE_INFO: PageInfoParams | undefined;
+  public static PREV_PAGE_INFO: PageInfoParams | undefined;
 
   public static CLIENT: typeof RestClient;
   public static CONFIG: ConfigInterface;
@@ -82,8 +82,8 @@ export class Base {
       params,
     });
 
-    this.NEXT_PAGE_INFO = response.pageInfo?.nextPage ?? undefined;
-    this.PREV_PAGE_INFO = response.pageInfo?.prevPage ?? undefined;
+    this.NEXT_PAGE_INFO = response.pageInfo?.nextPage;
+    this.PREV_PAGE_INFO = response.pageInfo?.prevPage;
 
     return this.createInstancesFromResponse<T>(session, response.body as Body);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #683 

Currently, the REST resource classes support paginated requests using the `PREV_PAGE_INFO` and `NEXT_PAGE_INFO` properties, but we didn't mention that anywhere in the docs, so it was very hard for partners to get information on how to use them.

### WHAT is this pull request doing?

Adding a new section in the REST resource guide covering that feature, and tweaking the types for those properties - we were using `GetRequestParams` which included fields that weren't really there.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
