### PR TITLE
Update shopify.dev links to include /docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,18 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE.md)
 [![npm version](https://badge.fury.io/js/%40shopify%2Fshopify-api.svg)](https://badge.fury.io/js/%40shopify%2Fshopify-api)
 
-This library provides support for the backends of TypeScript/JavaScript [Shopify](https://www.shopify.com) apps to access the [Shopify Admin API](https://shopify.dev/docs/admin-api), by making it easier to perform the following actions:
+This library provides support for the backends of TypeScript/JavaScript [Shopify](https://www.shopify.com) apps to access the [Shopify Admin API](https://shopify.dev/docs/api/admin), by making it easier to perform the following actions:
 
-- Creating [online](https://shopify.dev/apps/auth#online-access) or [offline](https://shopify.dev/apps/auth#offline-access) access tokens for the Admin API via OAuth
-- Making requests to the [REST API](https://shopify.dev/docs/admin-api/rest/reference)
-- Making requests to the [GraphQL API](https://shopify.dev/docs/admin-api/graphql/reference)
+- Creating [online](https://shopify.dev/docs/apps/auth#online-access) or [offline](https://shopify.dev/docs/apps/auth#offline-access) access tokens for the Admin API via OAuth
+- Making requests to the [REST API](https://shopify.dev/docs/api/admin/rest/reference)
+- Making requests to the [GraphQL API](https://shopify.dev/docs/api/admin/graphql/reference)
 - Register/process webhooks
 
-Once your app has access to the Admin API, you can also access the [Shopify Storefront API](https://shopify.dev/docs/storefront-api) to run GraphQL queries using the `unauthenticated_*` access scopes.
+Once your app has access to the Admin API, you can also access the [Shopify Storefront API](https://shopify.dev/docs/api/storefront) to run GraphQL queries using the `unauthenticated_*` access scopes.
 
 This library can be used in any application that runs on one of the supported runtimes. It doesn't rely on any specific framework, so you can include it alongside your preferred stack and only use the features that you need to build your app.
 
-**Note**: this package will enable your app's backend to work with Shopify APIs, but you'll need to use [Shopify App Bridge](https://shopify.dev/apps/tools/app-bridge) in your frontend if you're planning on embedding your app into the Shopify Admin.
+**Note**: this package will enable your app's backend to work with Shopify APIs, but you'll need to use [Shopify App Bridge](https://shopify.dev/docs/apps/tools/app-bridge) in your frontend if you're planning on embedding your app into the Shopify Admin.
 
 ## Requirements
 
@@ -61,7 +61,7 @@ Next, configure the library - you'll need some values in advance:
 
 - Your app's API key from [Partners dashboard](https://www.shopify.com/partners)
 - Your app's API secret from Partners dashboard
-- The [scopes](https://shopify.dev/api/usage/access-scopes) you need for your app
+- The [scopes](https://shopify.dev/docs/api/usage/access-scopes) you need for your app
 
 Call `shopifyApi` ([see reference](./docs/reference/shopifyApi.md)) to create your library object before setting up your app itself:
 

--- a/docs/example-migration-v5-node-template-to-v6.md
+++ b/docs/example-migration-v5-node-template-to-v6.md
@@ -501,7 +501,7 @@ import shopify from '../shopify.js';
  * merchant has an active one-time payment or subscription named `chargeName`. If no payment is found,
  * this helper requests it and returns a confirmation URL so that the merchant can approve the purchase.
  *
- * Learn more about billing in our documentation: https://shopify.dev/apps/billing
+ * Learn more about billing in our documentation: https://shopify.dev/docs/apps/billing
  */
 export default async function ensureBilling(
   session,
@@ -746,7 +746,7 @@ Pulling it all together!
  // the code when you store customer data.
  //
  // More details can be found on shopify.dev:
- // https://shopify.dev/apps/webhooks/configuration/mandatory-webhooks
+ // https://shopify.dev/docs/apps/webhooks/configuration/mandatory-webhooks
  setupGDPRWebHooks("/api/webhooks");
 
  // export for test use only

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -45,7 +45,7 @@ This setting is a collection of billing plans. Each billing plan allows the foll
 | `amount`              | `number`                     |    Yes    |       -       | The amount to charge                                                                                                                                         |
 | `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, currently only `"USD"` is accepted                                                                                                   |
 | `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                |
-| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/api/admin-graphql/2022-07/mutations/appSubscriptionCreate) for more information. |
+| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information. |
 
 ### Usage Billing Plans
 
@@ -56,7 +56,7 @@ This setting is a collection of billing plans. Each billing plan allows the foll
 | `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, currently only `"USD"` is accepted                                                                                                   |
 | `usageTerms`          | `string`                     |    Yes    |       -       | These terms stipulate the pricing model for the charges that an app creates.                                                                                 |
 | `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                |
-| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/api/admin-graphql/2022-07/mutations/appSubscriptionCreate) for more information. |
+| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information. |
 
 ## When should the app check for payment?
 
@@ -68,6 +68,6 @@ If you're gating access to the entire app, you should check for billing:
 1. After OAuth completes, you'll get the session back from [`shopify.auth.callback`](../reference/auth/callback.md). You can use the session to ensure billing takes place as part of the authentication flow.
 1. When validating requests from the frontend. Since the check requires API access, you can only run it in requests that work with [`shopify.session.getCurrentId`](../reference/session/getCurrentId.md).
 
-**Note**: the merchant may refuse payment when prompted or cancel subscriptions later on, but the app will already be installed at that point. We recommend using [billing webhooks](https://shopify.dev/apps/billing#webhooks-for-billing) to revoke access for merchants when they cancel / decline payment.
+**Note**: the merchant may refuse payment when prompted or cancel subscriptions later on, but the app will already be installed at that point. We recommend using [billing webhooks](https://shopify.dev/docs/apps/billing#webhooks-for-billing) to revoke access for merchants when they cancel / decline payment.
 
 [Back to guide index](../../README.md#guides)

--- a/docs/guides/oauth.md
+++ b/docs/guides/oauth.md
@@ -1,7 +1,7 @@
 # Performing OAuth
 
 After you set up the library for your project, you'll be able to use it to interact with the APIs, and add your own functionality.
-The first thing your app will need to do is to get a token to access the Admin API by performing the OAuth process. Learn more about [OAuth on the Shopify platform](https://shopify.dev/apps/auth/oauth).
+The first thing your app will need to do is to get a token to access the Admin API by performing the OAuth process. Learn more about [OAuth on the Shopify platform](https://shopify.dev/docs/apps/auth/oauth).
 
 To perform OAuth, you will need to create two endpoints in your app:
 

--- a/docs/guides/rest-resources.md
+++ b/docs/guides/rest-resources.md
@@ -83,7 +83,7 @@ The resource classes provide representations of all endpoints for the API resour
 1. `GET /products.json` maps to `Product.all()`
 1. `GET /products/count.json` maps to `Product.count()`
 
-Please visit our [REST API reference documentation](https://shopify.dev/api/admin-rest) for detailed instructions on how to call each of the endpoints.
+Please visit our [REST API reference documentation](https://shopify.dev/docs/api/admin-rest) for detailed instructions on how to call each of the endpoints.
 
 ## Mounting REST resources
 
@@ -106,7 +106,7 @@ From this point, you can start using the resources to interact with the API.
 
 ## Paginated requests
 
-Shopify's REST API supports [cursor-based pagination](https://shopify.dev/api/usage/pagination-rest), to limit the amount of data sent to an app on a single request.
+Shopify's REST API supports [cursor-based pagination](https://shopify.dev/docs/api/usage/pagination-rest), to limit the amount of data sent to an app on a single request.
 
 Each request will return the information required for an app to request the previous / next set of items.
 

--- a/docs/guides/webhooks.md
+++ b/docs/guides/webhooks.md
@@ -1,6 +1,6 @@
 # Setting up webhooks
 
-If your app needs to keep track of specific events happening on a shop, you can use [Shopify webhooks](https://shopify.dev/apps/webhooks) to subscribe to those events.
+If your app needs to keep track of specific events happening on a shop, you can use [Shopify webhooks](https://shopify.dev/docs/apps/webhooks) to subscribe to those events.
 
 To do that, you'll need to perform the following steps:
 

--- a/docs/migrating-to-v6.md
+++ b/docs/migrating-to-v6.md
@@ -219,7 +219,7 @@ See the [Changes to use of REST resources](#changes-to-use-of-rest-resources) se
 
 The OAuth methods still behave the same way, but we've updated their signatures to make it easier to work with them. See the [updated OAuth instructions](./guides/oauth.md) for a complete example.
 
-See [Access modes](https://shopify.dev/apps/auth/oauth/access-modes) for more details regarding how to use the `isOnline` parameter.
+See [Access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes) for more details regarding how to use the `isOnline` parameter.
 
 1. `Shopify.Auth.beginAuth()` is now `shopify.auth.begin()`, it takes in an object, and it now also triggers a redirect response to the correct endpoint.
    <div>Before

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,15 +4,15 @@ This section of the documentation provides thorough details on the parameters an
 
 ## [shopifyApi](./shopifyApi.md)
 
-| Property                            | Description                                                                                                                                        |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| config                              | The options used to set up the object, containing the parameters of this function.                                                                 |
-| [auth](./auth/README.md)            | Object containing functions to authenticate with Shopify APIs.                                                                                     |
-| [clients](./clients/README.md)      | Object containing clients to access Shopify APIs.                                                                                                  |
-| [session](./session/README.md)      | Object containing functions to manage Shopify sessions.                                                                                            |
-| [webhooks](./webhooks/README.md)    | Object containing functions to configure and handle Shopify webhooks.                                                                              |
-| [billing](./billing/README.md)      | Object containing functions to enable apps to bill merchants.                                                                                      |
-| [utils](./utils/README.md)          | Object containing general functions to help build apps.                                                                                            |
-| [rest](../guides/rest-resources.md) | Object containing OO representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/api/admin-rest) for details. |
+| Property                            | Description                                                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| config                              | The options used to set up the object, containing the parameters of this function.                                                                      |
+| [auth](./auth/README.md)            | Object containing functions to authenticate with Shopify APIs.                                                                                          |
+| [clients](./clients/README.md)      | Object containing clients to access Shopify APIs.                                                                                                       |
+| [session](./session/README.md)      | Object containing functions to manage Shopify sessions.                                                                                                 |
+| [webhooks](./webhooks/README.md)    | Object containing functions to configure and handle Shopify webhooks.                                                                                   |
+| [billing](./billing/README.md)      | Object containing functions to enable apps to bill merchants.                                                                                           |
+| [utils](./utils/README.md)          | Object containing general functions to help build apps.                                                                                                 |
+| [rest](../guides/rest-resources.md) | Object containing OO representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/docs/api/admin-rest) for details. |
 
 [Back to main page](../../README.md)

--- a/docs/reference/auth/begin.md
+++ b/docs/reference/auth/begin.md
@@ -53,7 +53,7 @@ The path to the callback endpoint, with a leading `/`. This URL must be allowed 
 
 `bool` | :exclamation: required
 
-`true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/apps/auth/oauth/access-modes).
+`true` if the session is online and `false` otherwise. Learn more about [OAuth access modes](https://shopify.dev/docs/apps/auth/oauth/access-modes).
 
 ### rawRequest
 

--- a/docs/reference/billing/README.md
+++ b/docs/reference/billing/README.md
@@ -2,7 +2,7 @@
 
 This object contains functions used to create and check billing charges with Shopify, based on the plans defined in the [`billing`](../shopifyApi.md#billing) configuration.
 
-Learn more about [how billing on Shopify works](https://shopify.dev/apps/billing).
+Learn more about [how billing on Shopify works](https://shopify.dev/docs/apps/billing).
 
 > **Note**: this package uses the GraphQL Admin API to look for and/or request payments, which means an app must go through OAuth before it can charge merchants.
 

--- a/docs/reference/clients/Graphql.md
+++ b/docs/reference/clients/Graphql.md
@@ -2,7 +2,7 @@
 
 Instances of this class can make requests to the Shopify Admin GraphQL API.
 
-> **Note**: You can use the [Shopify Admin API GraphiQL explorer](https://shopify.dev/apps/tools/graphiql-admin-api) to help build your queries.
+> **Note**: You can use the [Shopify Admin API GraphiQL explorer](https://shopify.dev/docs/apps/tools/graphiql-admin-api) to help build your queries.
 
 ## Constructor
 

--- a/docs/reference/clients/README.md
+++ b/docs/reference/clients/README.md
@@ -2,11 +2,11 @@
 
 This object contains functions used to authenticate apps, and redirect users to Shopify.
 
-| Property                          | Description                                                                                          |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| [Rest](./Rest.md)                 | Class that can interact with the [Shopify Admin REST API](https://shopify.dev/api/admin-rest).       |
-| [Graphql](./Graphql.md)           | Class that can interact with the [Shopify Admin GraphQL API](https://shopify.dev/api/admin-graphql). |
-| [Storefront](./Storefront.md)     | Class that can interact with the [Shopify Storefront API](https://shopify.dev/api/storefront).       |
-| [graphqlProxy](./graphqlProxy.md) | Creates a proxy that forwards requests to the GraphQL API and returns the response from Shopify.     |
+| Property                          | Description                                                                                               |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [Rest](./Rest.md)                 | Class that can interact with the [Shopify Admin REST API](https://shopify.dev/docs/api/admin-rest).       |
+| [Graphql](./Graphql.md)           | Class that can interact with the [Shopify Admin GraphQL API](https://shopify.dev/docs/api/admin-graphql). |
+| [Storefront](./Storefront.md)     | Class that can interact with the [Shopify Storefront API](https://shopify.dev/docs/api/storefront).       |
+| [graphqlProxy](./graphqlProxy.md) | Creates a proxy that forwards requests to the GraphQL API and returns the response from Shopify.          |
 
 [Back to shopifyApi](../shopifyApi.md)

--- a/docs/reference/clients/Storefront.md
+++ b/docs/reference/clients/Storefront.md
@@ -2,11 +2,11 @@
 
 Instances of this class can make requests to the Shopify Storefront API.
 
-> **Note**: ⚠️ This API limits request rates based on the IP address that calls it, which will be your server's address for all requests made by the library. The API uses a leaky bucket algorithm, with a default bucket size of 60 seconds of request processing time (minimum 0.5s per request), with a leak rate of 1/s. Learn more about [rate limits](https://shopify.dev/api/usage/rate-limits).
+> **Note**: ⚠️ This API limits request rates based on the IP address that calls it, which will be your server's address for all requests made by the library. The API uses a leaky bucket algorithm, with a default bucket size of 60 seconds of request processing time (minimum 0.5s per request), with a leak rate of 1/s. Learn more about [rate limits](https://shopify.dev/docs/api/usage/rate-limits).
 
 ## Requirements
 
-You can create Storefront API access tokens for both **private apps** and **sales channels**, but you **must use offline access tokens** for sales channels. Please read [our documentation](https://shopify.dev/docs/storefront-api/getting-started) to learn more about Storefront Access Tokens.
+You can create Storefront API access tokens for both **private apps** and **sales channels**, but you **must use offline access tokens** for sales channels. Please read [our documentation](https://shopify.dev/docs/custom-storefronts/building-with-the-storefront-api/products-collections/getting-started) to learn more about Storefront Access Tokens.
 
 If you are building a private app, you can set a default Storefront Access Token for all `Storefront` client instances by setting the `config.privateAppStorefrontAccessToken` property when calling [`shopifyApi`](../shopifyApi.md).
 
@@ -15,10 +15,10 @@ If you are building a private app, you can set a default Storefront Access Token
 ### Example
 
 Below is a (simplified) example of how you may create a token and construct a client.
-See the [REST](https://shopify.dev/api/admin-rest/latest/resources/storefrontaccesstoken) or [GraphQL](https://shopify.dev/api/admin-graphql/latest/mutations/storefrontAccessTokenCreate) Admin API references for more information.
+See the [REST](https://shopify.dev/docs/api/admin-rest/latest/resources/storefrontaccesstoken) or [GraphQL](https://shopify.dev/docs/api/admin-graphql/latest/mutations/storefrontAccessTokenCreate) Admin API references for more information.
 
 Once you've created your access token, you can query the Storefront API based on the `unauthenticated_*` scopes your app requests.
-See the [API reference documentation](https://shopify.dev/api/storefront) for detailed instructions on each component.
+See the [API reference documentation](https://shopify.dev/docs/api/storefront) for detailed instructions on each component.
 
 ```ts
 app.get('/my-endpoint', async (req, res) => {

--- a/docs/reference/session/decodeSessionToken.md
+++ b/docs/reference/session/decodeSessionToken.md
@@ -26,6 +26,6 @@ The token to parse.
 
 `Promise<JwtPayload>`
 
-The parsed JWT payload, matching the payload contained in [session tokens](https://shopify.dev/apps/auth/oauth/session-tokens#payload).
+The parsed JWT payload, matching the payload contained in [session tokens](https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload).
 
 [Back to shopify.session](./README.md)

--- a/docs/reference/session/getCurrentId.md
+++ b/docs/reference/session/getCurrentId.md
@@ -5,7 +5,7 @@ Extracts the Shopify session id from the given request.
 For embedded apps, `shopify.session.getCurrentId` will only be able to find a session id if you use `authenticatedFetch` from the `@shopify/app-bridge-utils` client-side package.
 This function behaves like a [normal `fetch` call](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), but ensures the appropriate headers are set.
 
-Learn more about [making authenticated requests](https://shopify.dev/apps/auth/oauth/session-tokens/getting-started#step-2-authenticate-your-requests) using App Bridge.
+Learn more about [making authenticated requests](https://shopify.dev/docs/apps/auth/oauth/session-tokens/getting-started#step-2-authenticate-your-requests) using App Bridge.
 
 ## Example
 
@@ -26,7 +26,7 @@ app.get('/fetch-some-data', async (req, res) => {
 });
 ```
 
-> **Note**: this method will rely on cookies for non-embedded apps, and the `Authorization` HTTP header for embedded apps using [App Bridge session tokens](https://shopify.dev/apps/auth/oauth/session-tokens), making all apps safe to use in modern browsers that block 3rd party cookies.
+> **Note**: this method will rely on cookies for non-embedded apps, and the `Authorization` HTTP header for embedded apps using [App Bridge session tokens](https://shopify.dev/docs/apps/auth/oauth/session-tokens), making all apps safe to use in modern browsers that block 3rd party cookies.
 
 ## Parameters
 

--- a/docs/reference/shopifyApi.md
+++ b/docs/reference/shopifyApi.md
@@ -57,7 +57,7 @@ API secret key for the app. You can find it in the Partners Dashboard.
 
 `string[] | AuthScopes` | :exclamation: **required**
 
-[Shopify scopes](https://shopify.dev/api/usage/access-scopes) required for your app.
+[Shopify scopes](https://shopify.dev/docs/api/usage/access-scopes) required for your app.
 
 ### hostName
 
@@ -81,7 +81,7 @@ API version your app will be querying. E.g. `ApiVersion.October22`.
 
 `boolean` | Defaults to `true`
 
-Whether your app will run within the Shopify Admin. Learn more about embedded apps with [`App Bridge`](https://shopify.dev/apps/tools/app-bridge/getting-started/app-setup).
+Whether your app will run within the Shopify Admin. Learn more about embedded apps with [`App Bridge`](https://shopify.dev/docs/apps/tools/app-bridge/getting-started/app-setup).
 
 ### isCustomStoreApp
 
@@ -157,15 +157,15 @@ Whether to add the current timestamp to every logged message.
 
 This function returns an object containing the following properties:
 
-| Property                            | Description                                                                                                                                        |
-| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| config                              | The options used to set up the object, containing the parameters of this function.                                                                 |
-| [auth](./auth/README.md)            | Object containing functions to authenticate with Shopify APIs.                                                                                     |
-| [clients](./clients/README.md)      | Object containing clients to access Shopify APIs.                                                                                                  |
-| [session](./session/README.md)      | Object containing functions to manage Shopify sessions.                                                                                            |
-| [webhooks](./webhooks/README.md)    | Object containing functions to configure and handle Shopify webhooks.                                                                              |
-| [billing](./billing/README.md)      | Object containing functions to enable apps to bill merchants.                                                                                      |
-| [utils](./utils/README.md)          | Object containing general functions to help build apps.                                                                                            |
-| [rest](../guides/rest-resources.md) | Object containing OO representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/api/admin-rest) for details. |
+| Property                            | Description                                                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| config                              | The options used to set up the object, containing the parameters of this function.                                                                      |
+| [auth](./auth/README.md)            | Object containing functions to authenticate with Shopify APIs.                                                                                          |
+| [clients](./clients/README.md)      | Object containing clients to access Shopify APIs.                                                                                                       |
+| [session](./session/README.md)      | Object containing functions to manage Shopify sessions.                                                                                                 |
+| [webhooks](./webhooks/README.md)    | Object containing functions to configure and handle Shopify webhooks.                                                                                   |
+| [billing](./billing/README.md)      | Object containing functions to enable apps to bill merchants.                                                                                           |
+| [utils](./utils/README.md)          | Object containing general functions to help build apps.                                                                                                 |
+| [rest](../guides/rest-resources.md) | Object containing OO representations of the Admin REST API. See the [API reference documentation](https://shopify.dev/docs/api/admin-rest) for details. |
 
 [Back to reference index](./README.md)

--- a/docs/reference/webhooks/addHandlers.md
+++ b/docs/reference/webhooks/addHandlers.md
@@ -2,7 +2,7 @@
 
 Adds webhook handlers to the library registry, allowing you to register them with Shopify and process HTTP webhook requests from Shopify.
 
-See the documentation for [the full list](https://shopify.dev/api/admin-graphql/latest/enums/WebhookSubscriptionTopic) of accepted topics.
+See the documentation for [the full list](https://shopify.dev/docs/api/admin-graphql/latest/enums/WebhookSubscriptionTopic) of accepted topics.
 
 > **Note**: you can only register multiple handlers with the same address when the delivery method is HTTP - the library will automatically chain the requests together when handling events.
 > The library will fail when trying to add duplicate paths for other delivery methods.

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -45,7 +45,7 @@ export type WebhookHandler =
   | PubSubWebhookHandler;
 
 export interface WebhookRegistry {
-  // See https://shopify.dev/docs/admin-api/graphql/reference/events/webhooksubscriptiontopic for available topics
+  // See https://shopify.dev/docs/api/admin-graphql/latest/enums/webhooksubscriptiontopic for available topics
   [topic: string]: WebhookHandler[];
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Much of the api and app related content has been moved under /docs on the Shopify Dev site. This updates the links to point to the new locations.  This change also updates some links to the new IA, avoiding extra redirects.

### WHAT is this pull request doing?

See above ☝🏻 
