### PR TITLE
[Feature] Global configuration to set default retries

### DIFF
--- a/docs/reference/shopifyApi.md
+++ b/docs/reference/shopifyApi.md
@@ -18,6 +18,7 @@ const shopify = shopifyApi({
   apiVersion: ApiVersion.July22,
   isEmbeddedApp: true,
   isCustomStoreApp: false,
+  defaultRetries: 1,
   userAgentPrefix: 'Custom prefix',
   privateAppStorefrontAccessToken: 'PrivateAccessToken',
   customShopDomains: ['*.my-custom-domain.io'],
@@ -86,6 +87,12 @@ Whether your app will run within the Shopify Admin. Learn more about embedded ap
 `boolean` | Defaults to `false`
 
 Whether you are building a private app for a store.
+
+### defaultRetries
+
+`number` | Defaults to `1`
+
+Set default retry attempts for Rest & GraphQL client.
 
 ### userAgentPrefix
 

--- a/lib/base-types.ts
+++ b/lib/base-types.ts
@@ -15,6 +15,7 @@ export interface ConfigParams<T extends ShopifyRestResources = any> {
   apiVersion: ApiVersion;
   isEmbeddedApp: boolean;
   isCustomStoreApp?: boolean;
+  defaultRetries?: number;
   userAgentPrefix?: string;
   privateAppStorefrontAccessToken?: string;
   customShopDomains?: (RegExp | string)[];

--- a/lib/clients/http_client/http_client.ts
+++ b/lib/clients/http_client/http_client.ts
@@ -84,7 +84,8 @@ export class HttpClient {
   protected async request<T = unknown>(
     params: RequestParams,
   ): Promise<RequestReturn<T>> {
-    const maxTries = params.tries ? params.tries : 1;
+    const config = this.httpClass().config;
+    const maxTries = params.tries ? params.tries : (config.defaultRetries ?? 1);
     if (maxTries <= 0) {
       throw new ShopifyErrors.HttpRequestError(
         `Number of tries must be >= 0, got ${maxTries}`,
@@ -93,7 +94,7 @@ export class HttpClient {
 
     let userAgent = `${LIBRARY_NAME} v${SHOPIFY_API_LIBRARY_VERSION} | ${abstractRuntimeString()}`;
 
-    if (this.httpClass().config.userAgentPrefix) {
+    if (config.userAgentPrefix) {
       userAgent = `${this.httpClass().config.userAgentPrefix} | ${userAgent}`;
     }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

For making RestAPI or GraphQL calls, developers often have to set default retries across the application. This is redundant. 

### WHAT is this pull request doing?

This PR is exposing a global configuration in `ConfigParams` and is later being used in the `HttpClient`.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
