### PR TITLE
Adds check for Google Crawler attempting to crawl Auth Routes

### DIFF
--- a/.changeset/unlucky-falcons-search.md
+++ b/.changeset/unlucky-falcons-search.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Adds check for Google's Crawler in the authorization functions to prevent CookieNotFound error loops. Fixes #686

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ bundle/
 *.js
 *.js.map
 *.tgz
+.vscode/
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["isbot"]
+}

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -552,7 +552,7 @@ describe('callback', () => {
     expect(responseCookies.shopify_app_session).toBeUndefined();
   });
 
-  test('callback returns undefined when the request is done by a bot', async () => {
+  test('callback throws an error when the request is done by a bot', async () => {
     const botRequest = {
       method: 'GET',
       url: 'https://my-test-app.myshopify.io/totally-real-request',
@@ -561,11 +561,11 @@ describe('callback', () => {
       },
     } as NormalizedRequest;
 
-    const callbackResponse = await shopify.auth.callback({
-      rawRequest: botRequest,
-    });
-
-    expect(callbackResponse).toEqual({headers: {}, session: {}});
+    await expect(
+      shopify.auth.callback({
+        rawRequest: botRequest,
+      }),
+    ).rejects.toThrow(ShopifyErrors.InvalidOAuthError);
   });
 
   test('properly updates the OAuth cookie for offline, non-embedded apps', async () => {

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -141,7 +141,7 @@ describe('beginAuth', () => {
     );
   });
 
-  test('response with a 418 when the request is a bot', async () => {
+  test('response with a 410 when the request is a bot', async () => {
     request.headers['User-Agent'] = 'Googlebot';
 
     const response: NormalizedResponse = await shopify.auth.begin({
@@ -151,7 +151,7 @@ describe('beginAuth', () => {
       rawRequest: request,
     });
 
-    expect(response.statusCode).toBe(418);
+    expect(response.statusCode).toBe(410);
   });
 
   test('fails to start if the app is private', () => {

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -565,7 +565,7 @@ describe('callback', () => {
       shopify.auth.callback({
         rawRequest: botRequest,
       }),
-    ).rejects.toThrow(ShopifyErrors.InvalidOAuthError);
+    ).rejects.toThrow(ShopifyErrors.BotActivityDetected);
   });
 
   test('properly updates the OAuth cookie for offline, non-embedded apps', async () => {

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -565,7 +565,7 @@ describe('callback', () => {
       rawRequest: botRequest,
     });
 
-    expect(callbackResponse).toBeUndefined();
+    expect(callbackResponse).toEqual({headers: {}, session: {}});
   });
 
   test('properly updates the OAuth cookie for offline, non-embedded apps', async () => {

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -328,10 +328,6 @@ describe('callback', () => {
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
 
-    if (callbackResponse === undefined) {
-      fail('Callback response is undefined');
-    }
-
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
     );
@@ -420,10 +416,6 @@ describe('callback', () => {
     });
     expect(currentSessionId).toEqual(jwtSessionId);
 
-    if (callbackResponse === undefined) {
-      fail('Callback response is undefined');
-    }
-
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
     );
@@ -472,10 +464,6 @@ describe('callback', () => {
     queueMockResponse(JSON.stringify(successResponse));
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
-
-    if (callbackResponse === undefined) {
-      fail('Callback response is undefined');
-    }
 
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
@@ -536,10 +524,6 @@ describe('callback', () => {
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
 
-    if (callbackResponse === undefined) {
-      fail('Callback response is undefined');
-    }
-
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
     );
@@ -599,10 +583,6 @@ describe('callback', () => {
     queueMockResponse(JSON.stringify(successResponse));
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
-
-    if (callbackResponse === undefined) {
-      fail('Callback response is undefined');
-    }
 
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],

--- a/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/lib/auth/oauth/__tests__/oauth.test.ts
@@ -260,7 +260,9 @@ describe('callback', () => {
     queueMockResponse(JSON.stringify(successResponse));
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
-
+    if (!callbackResponse) {
+      fail('Callback response is undefined');
+    }
     const expectedId = `offline_${shop}`;
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
@@ -312,6 +314,10 @@ describe('callback', () => {
     queueMockResponse(JSON.stringify(successResponse));
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
+
+    if (callbackResponse === undefined) {
+      fail('Callback response is undefined');
+    }
 
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
@@ -401,6 +407,10 @@ describe('callback', () => {
     });
     expect(currentSessionId).toEqual(jwtSessionId);
 
+    if (callbackResponse === undefined) {
+      fail('Callback response is undefined');
+    }
+
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
     );
@@ -449,6 +459,10 @@ describe('callback', () => {
     queueMockResponse(JSON.stringify(successResponse));
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
+
+    if (callbackResponse === undefined) {
+      fail('Callback response is undefined');
+    }
 
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
@@ -509,6 +523,10 @@ describe('callback', () => {
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
 
+    if (callbackResponse === undefined) {
+      fail('Callback response is undefined');
+    }
+
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],
     );
@@ -552,6 +570,10 @@ describe('callback', () => {
     queueMockResponse(JSON.stringify(successResponse));
 
     const callbackResponse = await shopify.auth.callback({rawRequest: request});
+
+    if (callbackResponse === undefined) {
+      fail('Callback response is undefined');
+    }
 
     const responseCookies = Cookies.parseCookies(
       callbackResponse.headers['Set-Cookie'],

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -120,7 +120,7 @@ export function begin(config: ConfigInterface) {
 export function callback(config: ConfigInterface) {
   return async function callback<T = AdapterHeaders>({
     ...adapterArgs
-  }: CallbackParams): Promise<CallbackResponse<T> | undefined> {
+  }: CallbackParams): Promise<CallbackResponse<T>> {
     throwIfCustomStoreApp(
       config.isCustomStoreApp,
       'Cannot perform OAuth for private apps',

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -1,4 +1,5 @@
 import {v4 as uuidv4} from 'uuid';
+import isbot from 'isbot';
 
 import ProcessedQuery from '../../utils/processed-query';
 import {ConfigInterface} from '../../base-types';
@@ -48,7 +49,7 @@ interface BotCheckArgs {
 
 const respondToPossibleBotRequest = (args: BotCheckArgs) => {
   const {request, shop, log} = args;
-  if (request.headers['User-Agent']?.includes('GoogleOther') || !shop) {
+  if (isbot(request.headers['User-Agent'])) {
     log.debug('Possible bot request to auth callback: ', {
       userAgent: request.headers['User-Agent'],
       shop,

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -139,7 +139,7 @@ export function callback(config: ConfigInterface) {
     const response = {} as NormalizedResponse;
     if (isbot(request.headers['User-Agent'])) {
       logForBot({request, log, func: 'callback'});
-      throw new ShopifyErrors.InvalidOAuthError(
+      throw new ShopifyErrors.BotActivityDetected(
         'Invalid OAuth callback initiated by bot',
       );
     }

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -73,7 +73,7 @@ export function begin(config: ConfigInterface) {
 
     if (isbot(request.headers['User-Agent'])) {
       logForBot({request, log, func: 'begin'});
-      response.statusCode = 418;
+      response.statusCode = 410;
       return abstractConvertResponse(response, adapterArgs);
     }
 

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -120,7 +120,7 @@ export function begin(config: ConfigInterface) {
 export function callback(config: ConfigInterface) {
   return async function callback<T = AdapterHeaders>({
     ...adapterArgs
-  }: CallbackParams): Promise<CallbackResponse<T> | undefined> {
+  }: CallbackParams): Promise<CallbackResponse<T>> {
     throwIfCustomStoreApp(
       config.isCustomStoreApp,
       'Cannot perform OAuth for private apps',
@@ -139,7 +139,10 @@ export function callback(config: ConfigInterface) {
     const response = {} as NormalizedResponse;
     if (isbot(request.headers['User-Agent'])) {
       logForBot({request, log, func: 'callback'});
-      return undefined;
+      return {
+        headers: (await abstractConvertHeaders({}, adapterArgs)) as T,
+        session: {} as Session,
+      };
     }
 
     log.info('Completing OAuth', {shop});

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -120,7 +120,7 @@ export function begin(config: ConfigInterface) {
 export function callback(config: ConfigInterface) {
   return async function callback<T = AdapterHeaders>({
     ...adapterArgs
-  }: CallbackParams): Promise<CallbackResponse<T>> {
+  }: CallbackParams): Promise<CallbackResponse<T> | undefined> {
     throwIfCustomStoreApp(
       config.isCustomStoreApp,
       'Cannot perform OAuth for private apps',
@@ -139,10 +139,9 @@ export function callback(config: ConfigInterface) {
     const response = {} as NormalizedResponse;
     if (isbot(request.headers['User-Agent'])) {
       logForBot({request, log, func: 'callback'});
-      return {
-        headers: (await abstractConvertHeaders({}, adapterArgs)) as T,
-        session: {} as Session,
-      };
+      throw new ShopifyErrors.InvalidOAuthError(
+        'Invalid OAuth callback initiated by bot',
+      );
     }
 
     log.info('Completing OAuth', {shop});

--- a/lib/auth/oauth/oauth.ts
+++ b/lib/auth/oauth/oauth.ts
@@ -41,8 +41,14 @@ export interface CallbackResponse<T = AdapterHeaders> {
   session: Session;
 }
 
-const logForBot = (request: NormalizedRequest, log: ShopifyLogger) => {
-  log.debug('Possible bot request to auth callback: ', {
+interface BotLog {
+  request: NormalizedRequest;
+  log: ShopifyLogger;
+  func: string;
+}
+
+const logForBot = ({request, log, func}: BotLog) => {
+  log.debug(`Possible bot request to auth ${func}: `, {
     userAgent: request.headers['User-Agent'],
   });
 };
@@ -66,7 +72,7 @@ export function begin(config: ConfigInterface) {
     const response = await abstractConvertIncomingResponse(adapterArgs);
 
     if (isbot(request.headers['User-Agent'])) {
-      logForBot(request, log);
+      logForBot({request, log, func: 'begin'});
       response.statusCode = 418;
       return abstractConvertResponse(response, adapterArgs);
     }
@@ -132,7 +138,7 @@ export function callback(config: ConfigInterface) {
 
     const response = {} as NormalizedResponse;
     if (isbot(request.headers['User-Agent'])) {
-      logForBot(request, log);
+      logForBot({request, log, func: 'callback'});
       return undefined;
     }
 

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -87,6 +87,7 @@ export class GraphqlQueryError extends ShopifyError {
 }
 
 export class InvalidOAuthError extends ShopifyError {}
+export class BotActivityDetected extends ShopifyError {}
 export class CookieNotFound extends ShopifyError {}
 export class InvalidSession extends ShopifyError {}
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "dependencies": {
     "@shopify/network": "^3.2.1",
     "compare-versions": "^5.0.3",
+    "isbot": "^3.6.10",
     "jose": "^4.9.1",
     "node-fetch": "^2.6.1",
     "tslib": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4109,6 +4109,11 @@ is-windows@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+isbot@^3.6.10:
+  version "3.6.10"
+  resolved "https://registry.yarnpkg.com/isbot/-/isbot-3.6.10.tgz#7b66334e81794f0461794debb567975cf08eaf2b"
+  integrity sha512-+I+2998oyP4oW9+OTQD8TS1r9P6wv10yejukj+Ksj3+UR5pUhsZN3f8W7ysq0p1qxpOVNbl5mCuv0bCaF8y5iQ==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"


### PR DESCRIPTION
### WHY are these changes introduced?

~~Fixes~~ Related to #686

Users were seeing logs with multiple auth requests coming in failing on missing cookies. We determined that in Chrome google's crawler was sending additional requests to the auth and auth/callback endpoints for our test app with the user-agent "GoogleOther" which would not have cookies set nor shop and other parameters available.

### WHAT is this pull request doing?

Adds a check against the google crawler user agent and for missing shop params, then throws an error (based on needed discussion)

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
