### PR TITLE
[Fix] Replace `semver` (uses node builtin libs) with `compare-versions` (pure javascript)

### DIFF
--- a/.changeset/curvy-gorillas-smoke.md
+++ b/.changeset/curvy-gorillas-smoke.md
@@ -2,4 +2,4 @@
 '@shopify/shopify-api': patch
 ---
 
-replace `semver` with `compare-versions` lib to reduce dependency on nodejs builtin-libs
+Replace `semver` with `compare-versions` lib to reduce dependency on nodejs builtin-libs

--- a/.changeset/curvy-gorillas-smoke.md
+++ b/.changeset/curvy-gorillas-smoke.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+replace `semver` with `compare-versions` lib to reduce dependency on nodejs builtin-libs

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,5 @@
 import type {Config} from 'jest';
-import semver from 'semver';
+import {compare as semver} from 'compare-versions';
 
 const projects = [
   './lib/__tests__/jest_projects/library.jest.config.ts',
@@ -11,7 +11,7 @@ const projects = [
 
 // eslint-disable-next-line no-warning-comments
 // TODO Make all projects permanent after support for version 14 is dropped
-if (semver.gte(process.version, '15.0.0')) {
+if (semver(process.version, '15.0.0', '>=')) {
   projects.push(
     './lib/__tests__/jest_projects/adapters.cf-worker.jest.config.ts',
   );

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,5 @@
 import type {Config} from 'jest';
-import {compare as semver} from 'compare-versions';
+import {compare} from 'compare-versions';
 
 const projects = [
   './lib/__tests__/jest_projects/library.jest.config.ts',
@@ -11,7 +11,7 @@ const projects = [
 
 // eslint-disable-next-line no-warning-comments
 // TODO Make all projects permanent after support for version 14 is dropped
-if (semver(process.version, '15.0.0', '>=')) {
+if (compare(process.version, '15.0.0', '>=')) {
   projects.push(
     './lib/__tests__/jest_projects/adapters.cf-worker.jest.config.ts',
   );

--- a/lib/__tests__/test-helper.ts
+++ b/lib/__tests__/test-helper.ts
@@ -1,5 +1,5 @@
 import * as jose from 'jose';
-import {compare as semver} from 'compare-versions';
+import {compare} from 'compare-versions';
 
 import {shopifyApi, Shopify} from '..';
 import {LATEST_API_VERSION, LogSeverity} from '../types';
@@ -165,7 +165,7 @@ export function testIfLibraryVersionIsAtLeast(
   testFn: jest.ProvidesCallback,
 ) {
   describe(`when library version is at least ${version}`, () => {
-    if (semver(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
+    if (compare(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
       test(testName, testFn);
     } else {
       test.skip(`- '${testName}' requires library version ${version} or higher`, () => {});

--- a/lib/__tests__/test-helper.ts
+++ b/lib/__tests__/test-helper.ts
@@ -1,5 +1,5 @@
 import * as jose from 'jose';
-import semver from 'semver';
+import {compare as semver} from 'compare-versions';
 
 import {shopifyApi, Shopify} from '..';
 import {LATEST_API_VERSION, LogSeverity} from '../types';
@@ -165,7 +165,7 @@ export function testIfLibraryVersionIsAtLeast(
   testFn: jest.ProvidesCallback,
 ) {
   describe(`when library version is at least ${version}`, () => {
-    if (semver.gte(SHOPIFY_API_LIBRARY_VERSION, version)) {
+    if (semver(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
       test(testName, testFn);
     } else {
       test.skip(`- '${testName}' requires library version ${version} or higher`, () => {});

--- a/lib/logger/index.ts
+++ b/lib/logger/index.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import {compare as semver} from 'compare-versions';
 
 import {LogSeverity} from '../types';
 import {ConfigInterface} from '../base-types';
@@ -29,7 +29,7 @@ export type ShopifyLogger = ReturnType<typeof logger>;
 
 function deprecated(logFunction: LoggerFunction) {
   return function (version: string, message: string): void {
-    if (semver.gte(SHOPIFY_API_LIBRARY_VERSION, version)) {
+    if (semver(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
       throw new FeatureDeprecatedError(
         `Feature was deprecated in version ${version}`,
       );

--- a/lib/logger/index.ts
+++ b/lib/logger/index.ts
@@ -1,4 +1,4 @@
-import {compare as semver} from 'compare-versions';
+import {compare} from 'compare-versions';
 
 import {LogSeverity} from '../types';
 import {ConfigInterface} from '../base-types';
@@ -29,7 +29,7 @@ export type ShopifyLogger = ReturnType<typeof logger>;
 
 function deprecated(logFunction: LoggerFunction) {
   return function (version: string, message: string): void {
-    if (semver(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
+    if (compare(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
       throw new FeatureDeprecatedError(
         `Feature was deprecated in version ${version}`,
       );

--- a/lib/setup-jest.ts
+++ b/lib/setup-jest.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import {compare as semver} from 'compare-versions';
 
 import '../adapters/mock';
 import {mockTestRequests} from '../adapters/mock/mock_test_requests';
@@ -131,7 +131,7 @@ expect.extend({
     return {
       message: () =>
         `Found deprecation limited to version ${version}, please update or remove it.`,
-      pass: semver.lt(SHOPIFY_API_LIBRARY_VERSION, version),
+      pass: semver(SHOPIFY_API_LIBRARY_VERSION, version, '<'),
     };
   },
 });

--- a/lib/setup-jest.ts
+++ b/lib/setup-jest.ts
@@ -1,4 +1,4 @@
-import {compare as semver} from 'compare-versions';
+import {compare} from 'compare-versions';
 
 import '../adapters/mock';
 import {mockTestRequests} from '../adapters/mock/mock_test_requests';
@@ -131,7 +131,7 @@ expect.extend({
     return {
       message: () =>
         `Found deprecation limited to version ${version}, please update or remove it.`,
-      pass: semver(SHOPIFY_API_LIBRARY_VERSION, version, '<'),
+      pass: compare(SHOPIFY_API_LIBRARY_VERSION, version, '<'),
     };
   },
 });

--- a/lib/utils/versioned-codeblocks.ts
+++ b/lib/utils/versioned-codeblocks.ts
@@ -1,9 +1,9 @@
-import semver from 'semver';
+import {compare as semver} from 'compare-versions';
 
 import {SHOPIFY_API_LIBRARY_VERSION} from '../version';
 
 export function enableCodeAfterVersion(version: string, fn: () => void): void {
-  if (semver.gte(SHOPIFY_API_LIBRARY_VERSION, version)) {
+  if (semver(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
     fn();
   }
 }

--- a/lib/utils/versioned-codeblocks.ts
+++ b/lib/utils/versioned-codeblocks.ts
@@ -1,9 +1,9 @@
-import {compare as semver} from 'compare-versions';
+import {compare} from 'compare-versions';
 
 import {SHOPIFY_API_LIBRARY_VERSION} from '../version';
 
 export function enableCodeAfterVersion(version: string, fn: () => void): void {
-  if (semver(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
+  if (compare(SHOPIFY_API_LIBRARY_VERSION, version, '>=')) {
     fn();
   }
 }

--- a/package.json
+++ b/package.json
@@ -75,11 +75,9 @@
   },
   "dependencies": {
     "@shopify/network": "^3.2.1",
-    "@types/node-fetch": "^2.5.7",
-    "@types/supertest": "^2.0.10",
+    "compare-versions": "^6.0.0-rc.1",
     "jose": "^4.9.1",
     "node-fetch": "^2.6.1",
-    "semver": "^7.3.8",
     "tslib": "^2.0.3",
     "uuid": "^9.0.0"
   },
@@ -94,7 +92,8 @@
     "@types/express": "^4.17.13",
     "@types/jest": "^29.5.0",
     "@types/node": "^14.18.12",
-    "@types/semver": "^7.3.12",
+    "@types/node-fetch": "^2.5.7",
+    "@types/supertest": "^2.0.10",
     "@types/uuid": "^9.0.0",
     "eslint": "^7.30.0",
     "express": "^4.17.13",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "dependencies": {
     "@shopify/network": "^3.2.1",
-    "compare-versions": "^6.0.0-rc.1",
+    "compare-versions": "^5.0.3",
     "jose": "^4.9.1",
     "node-fetch": "^2.6.1",
     "tslib": "^2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2526,10 +2526,10 @@ commondir@^1.0.1:
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
-compare-versions@^6.0.0-rc.1:
-  version "6.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.0.0-rc.1.tgz#93e6beb8767c2375333ee168fa64c28b75ace2c6"
-  integrity sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ==
+compare-versions@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-5.0.3.tgz#a9b34fea217472650ef4a2651d905f42c28ebfd7"
+  integrity sha512-4UZlZP8Z99MGEY+Ovg/uJxJuvoXuN4M6B3hKaiackiHrgzQFEe3diJi1mf1PNHbFujM7FvLrK2bpgIaImbtZ1A==
 
 component-emitter@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,11 +1799,6 @@
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.3.tgz#5798ecf1bec94eaa64db39ee52808ec0693315aa"
   integrity sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==
 
-"@types/semver@^7.3.12":
-  version "7.3.13"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
-  integrity sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==
-
 "@types/serve-static@*":
   version "1.15.0"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
@@ -2530,6 +2525,11 @@ commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
+
+compare-versions@^6.0.0-rc.1:
+  version "6.0.0-rc.1"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-6.0.0-rc.1.tgz#93e6beb8767c2375333ee168fa64c28b75ace2c6"
+  integrity sha512-cFhkjbGY1jLFWIV7KegECbfuyYPxSGvgGkdkfM+ibboQDoPwg2FRHm5BSNTOApiauRBzJIQH7qvOJs2sW5ueKQ==
 
 component-emitter@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #835 

Replaced [`semver`](https://www.npmjs.com/package/semver) package which had NodeJS built-in libs with [`compare-versions`](https://www.npmjs.com/package/compare-versions) package which is a pure JavaScript implementation.

### WHAT is this pull request doing?

Replaces `semver` package occurrences with `compare-versions` to reduce dependency on NodeJS built-in libs. Kept the naming intact for easier readability.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ Not applicable
