### PR TITLE
Makes apiKey optional when isCustomStoreApp=true

### DIFF
--- a/.changeset/nine-flies-drop.md
+++ b/.changeset/nine-flies-drop.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+apiKey configuration parameter is not mandatory when isCustomStoreApp is true. Fixes 782

--- a/docs/guides/custom-store-app.md
+++ b/docs/guides/custom-store-app.md
@@ -28,12 +28,10 @@ import { shopifyApi, ApiVersion, Session } from "@shopify/shopify-api";
 import { restResources } from "@shopify/shopify-api/rest/admin/2023-04";
 
 const shopify = shopifyApi({
-  apiKey: "App_API_key",
   apiSecretKey: "App_API_secret_key",            // Note: this is the API Secret Key, NOT the API access token
   apiVersion: ApiVersion.April23,
   isCustomStoreApp: true,                        // this MUST be set to true (default is false)
   adminApiAccessToken: "Admin_API_Access_Token", // Note: this is the API access token, NOT the API Secret Key
-  scopes: [],
   isEmbeddedApp: false,
   hostName: "my-shop.myshopify.com",
   // Mount REST resources.

--- a/lib/__tests__/config.test.ts
+++ b/lib/__tests__/config.test.ts
@@ -88,10 +88,21 @@ describe('Config object', () => {
     expect(() => validateConfig(empty)).toThrow(ShopifyErrors.ShopifyError);
   });
 
-  it("ignores an empty 'scopes' when isCustomStoreApp is true", () => {
+  it("ignores a missing 'scopes' when isCustomStoreApp is true", () => {
     validParams.isCustomStoreApp = true;
     validParams.adminApiAccessToken = 'token';
     delete (validParams as any).scopes;
+
+    expect(() => validateConfig(validParams)).not.toThrow(
+      ShopifyErrors.ShopifyError,
+    );
+    validParams.isCustomStoreApp = false;
+  });
+
+  it("ignores a missing 'apiKey' when isCustomStoreApp is true", () => {
+    validParams.isCustomStoreApp = true;
+    validParams.adminApiAccessToken = 'token';
+    delete (validParams as any).apiKey;
 
     expect(() => validateConfig(validParams)).not.toThrow(
       ShopifyErrors.ShopifyError,

--- a/lib/base-types.ts
+++ b/lib/base-types.ts
@@ -7,9 +7,9 @@ import {ApiVersion, LogSeverity} from './types';
 export type LogFunction = (severity: LogSeverity, msg: string) => void;
 
 export interface ConfigParams<T extends ShopifyRestResources = any> {
-  apiKey: string;
+  apiKey?: string;
   apiSecretKey: string;
-  scopes: string[] | AuthScopes;
+  scopes?: string[] | AuthScopes;
   hostName: string;
   hostScheme?: 'http' | 'https';
   apiVersion: ApiVersion;
@@ -30,6 +30,7 @@ export interface ConfigParams<T extends ShopifyRestResources = any> {
 }
 
 export interface ConfigInterface extends Omit<ConfigParams, 'restResources'> {
+  apiKey: string;
   hostScheme: 'http' | 'https';
   scopes: AuthScopes;
   isCustomStoreApp: boolean;

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -24,12 +24,9 @@ export function validateConfig(params: ConfigParams<any>): ConfigInterface {
   };
 
   // Make sure that the essential params actually have content in them
-  const mandatory: (keyof ConfigParams)[] = [
-    'apiKey',
-    'apiSecretKey',
-    'hostName',
-  ];
+  const mandatory: (keyof ConfigParams)[] = ['apiSecretKey', 'hostName'];
   if (!('isCustomStoreApp' in params) || !params.isCustomStoreApp) {
+    mandatory.push('apiKey');
     mandatory.push('scopes');
   }
   enableCodeAfterVersion('8.0.0', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

`apiKey` configuration parameter is not mandatory when `isCustomStoreApp` is `true`.

Fixes 782

### WHAT is this pull request doing?

Only adds `apiKey` to mandatory parameter list when `isCustomStoreApp` is `false` or missing.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
