### PR TITLE
[Feat] added cancel function for the billing api

### DIFF
--- a/.changeset/tall-rings-knock.md
+++ b/.changeset/tall-rings-knock.md
@@ -1,0 +1,14 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Added Subscription cancel capabilities for App Billing. Fixes #771
+
+Usage:
+
+```js
+const canceledSubscription = await shopify.billing.cancel({
+  session,
+  subscriptionId,
+})
+```

--- a/.changeset/tall-rings-knock.md
+++ b/.changeset/tall-rings-knock.md
@@ -12,3 +12,5 @@ const canceledSubscription = await shopify.billing.cancel({
   subscriptionId,
 })
 ```
+
+See [Billing Guide](https://github.com/shopify/shopify-api-js/blob/main/docs/guides/billing.md) for more details.

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -84,15 +84,45 @@ If you're gating access to the entire app, you should check for billing:
 
 ## Canceling a subscription
 
-With the `cancel` method you'll be able to cancel a single subscription. If you're not storing subscription ids already you can use the `check` method now to get the id of an active subscription before canceling it. The `cancel` method will require the `session` object that is setup during Authorization as well as the subscription id.
-
-The call to `cancel` will return an AppSubscription object and will throw a `BillingError` if any errors occur.
+With the `cancel` method you'll be able to cancel a single subscription. First, you'll need to obtain the id for the subscription you wish to cancel, using the `subscriptions` method.
 
 ```js
+const activeSubscriptions = await shopify.api.billing.subscriptions({
+  session: res.locals.shopify.session,
+});
+
+// activeSubscriptions will be an array of subscription details, e.g.,
+// [
+//   {
+//     "name": "My Shopify Subscription Charge",
+//     "id": "gid://shopify/AppSubscription/1234567890",
+//     "test": true
+//   },
+// ],
+```
+
+The `cancel` method will require the `session` object that is setup during authorization as well as the subscription id.
+
+The call to `cancel` will return an `CancelResponse` object, containing the current active subscriptions, and will throw a `BillingError` if any errors occur.
+
+```js
+// using the example activeSubscriptions response above...
+const subscriptionId = activeSubscriptions[0].id;  // "gid://shopify/AppSubscription/1234567890"
 const canceledSubscription = await shopify.billing.cancel({
   session,
   subscriptionId,
+  prorate: true,  // Whether to issue prorated credits for the unused portion of the app subscription. Defaults to true.
 })
+
+// canceledSubscription will have the following shape:
+// {
+//   data: {
+//     currentAppInstallation: ActiveSubscriptions;
+//   };
+//   errors?: string[];
+// }
 ```
+
+See the [billing reference](../reference/billing/README.md) for details on how to call the `subscriptions` and `cancel` endpoints.
 
 [Back to guide index](../../README.md#guides)

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -82,4 +82,17 @@ If you're gating access to the entire app, you should check for billing:
 
 **Note**: the merchant may refuse payment when prompted or cancel subscriptions later on, but the app will already be installed at that point. We recommend using [billing webhooks](https://shopify.dev/docs/apps/billing#webhooks-for-billing) to revoke access for merchants when they cancel / decline payment.
 
+## Canceling a subscription
+
+With the `cancel` method you'll be able to cancel a single subscription. If you're not storing subscription ids already you can use the `check` method now to get the id of an active subscription before canceling it. The `cancel` method will require the `session` object that is setup during Authorization as well as the subscription id.
+
+The call to `cancel` will return an AppSubscription object and will throw a `BillingError` if any errors occur.
+
+```js
+const canceledSubscription = await shopify.billing.cancel({
+  session,
+  subscriptionId,
+})
+```
+
 [Back to guide index](../../README.md#guides)

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -103,7 +103,7 @@ const activeSubscriptions = await shopify.api.billing.subscriptions({
 
 The `cancel` method will require the `session` object that is setup during authorization as well as the subscription id.
 
-The call to `cancel` will return an `CancelResponse` object, containing the current active subscriptions, and will throw a `BillingError` if any errors occur.
+The call to `cancel` will return an `AppSubscription` object, containing the details of the subscription just cancelled successfully, and will throw a `BillingError` if any errors occur.
 
 ```js
 // using the example activeSubscriptions response above...
@@ -116,10 +116,9 @@ const canceledSubscription = await shopify.billing.cancel({
 
 // canceledSubscription will have the following shape:
 // {
-//   data: {
-//     currentAppInstallation: ActiveSubscriptions;
-//   };
-//   errors?: string[];
+//   id: string;
+//   name: string;
+//   test: boolean;
 // }
 ```
 

--- a/docs/reference/billing/README.md
+++ b/docs/reference/billing/README.md
@@ -6,9 +6,11 @@ Learn more about [how billing on Shopify works](https://shopify.dev/docs/apps/bi
 
 > **Note**: this package uses the GraphQL Admin API to look for and/or request payments, which means an app must go through OAuth before it can charge merchants.
 
-| Property                | Description                                                     |
-| ----------------------- | --------------------------------------------------------------- |
-| [check](./check.md)     | Checks if the current shop has paid for any of the given plans. |
-| [request](./request.md) | Requests a new payment for the given payment plan.              |
+| Property                            | Description                                                          |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| [check](./check.md)                 | Checks if the current shop has paid for any of the given plans.      |
+| [request](./request.md)             | Requests a new payment for the given payment plan.                   |
+| [cancel](./cancel.md)               | Cancel a subscription plan using the given subscription id.          |
+| [subscriptions](./subscriptions.md) | Get a list of subscription plans that the current shop has paid for. |
 
 [Back to shopifyApi](../shopifyApi.md)

--- a/docs/reference/billing/cancel.md
+++ b/docs/reference/billing/cancel.md
@@ -6,7 +6,7 @@ Cancel a subscription plan by the given id.
 
 ### Cancel a subscription plan, given an id
 
-The call to `cancel` will return an `CancelResponse` object, containing the current active subscriptions, and will throw a `BillingError` if any errors occur.
+The call to `cancel` will return an `AppSubscription` object, containing the details of the subscription just cancelled successfully, and will throw a `BillingError` if any errors occur.
 
 ```ts
 const subscriptionId = "gid://shopify/AppSubscription/1234567890"; // this can be obtained from a call to shopify.billing.subscriptions()
@@ -24,9 +24,9 @@ try {
 }
 // canceledSubscription will have the following shape:
 // {
-//   data: {
-//     currentAppInstallation: ActiveSubscriptions;
-//   };
+//   id: string;
+//   name: string;
+//   test: boolean;
 // }
 ```
 
@@ -54,29 +54,15 @@ Whether to issue prorated credits for the unused portion of the app subscription
 
 ## Return
 
-`CancelResponse`
+`AppSubscription`
 
-An object containing a `data` object with a list of the current app subscriptions after a successful cancel with the following shape:
+An object containing the `id`, `name` and `test` properties of the subscription that was just successfully cancelled:
 
 ```ts
 {
-  data: {
-    currentAppInstallation: {
-      activeSubscriptions: [
-        {
-          id: string;
-          name: string;
-          test: boolean;
-        },
-        {
-          id: string;
-          name: string;
-          test: boolean;
-        },
-        // ...
-      ];
-    },
-  },
+  id: string;
+  name: string;
+  test: boolean;
 }
 ```
 

--- a/docs/reference/billing/cancel.md
+++ b/docs/reference/billing/cancel.md
@@ -1,0 +1,85 @@
+# shopify.billing.cancel
+
+Cancel a subscription plan by the given id.
+
+## Example
+
+### Cancel a subscription plan, given an id
+
+The call to `cancel` will return an `CancelResponse` object, containing the current active subscriptions, and will throw a `BillingError` if any errors occur.
+
+```ts
+const subscriptionId = "gid://shopify/AppSubscription/1234567890"; // this can be obtained from a call to shopify.billing.subscriptions()
+try {
+  const canceledSubscription = await shopify.billing.cancel({
+    session,
+    subscriptionId,
+    prorate: true,  // Whether to issue prorated credits for the unused portion of the app subscription. Defaults to true.
+  })
+} catch (error) {
+  if (error typeof BillingError) {
+    console.log(`Unable to cancel subscription ${subscriptionId}: ${JSON.stringify(error.errorData, null, 2)}`);
+    // handle error appropriately
+  }
+}
+// canceledSubscription will have the following shape:
+// {
+//   data: {
+//     currentAppInstallation: ActiveSubscriptions;
+//   };
+// }
+```
+
+## Parameters
+
+Receives an object containing:
+
+### session
+
+`Session` | :exclamation: required
+
+The `Session` for the current request.
+
+### subscriptionId
+
+`string` | :exclamation: required
+
+The id for the subscription to cancel.
+
+### prorate
+
+`boolean` | optional, defaults to `true`
+
+Whether to issue prorated credits for the unused portion of the app subscription. Defaults to true.
+
+## Return
+
+`CancelResponse`
+
+An object containing a `data` object with a list of the current app subscriptions after a successful cancel with the following shape:
+
+```ts
+{
+  data: {
+    currentAppInstallation: {
+      activeSubscriptions: [
+        {
+          id: string;
+          name: string;
+          test: boolean;
+        },
+        {
+          id: string;
+          name: string;
+          test: boolean;
+        },
+        // ...
+      ];
+    },
+  },
+}
+```
+
+If the call to `shopify.billing.cancel` throws a `BillingError`, the `BillingError` object will contain an array of error messages returned by the GraphQL API call in the `errorData` property.
+
+[Back to shopify.billing](./README.md)

--- a/docs/reference/billing/subscriptions.md
+++ b/docs/reference/billing/subscriptions.md
@@ -1,0 +1,77 @@
+# shopify.billing.subscriptions
+
+Returns a list of subscription plans for which the app has already paid.
+
+## Example
+
+### List active subscriptions for current shop
+
+```ts
+app.get('/api/list-subscriptions', async (req, res) => {
+  const sessionId = shopify.session.getCurrentId({
+    isOnline: true,
+    rawRequest: req,
+    rawResponse: res,
+  });
+
+  // use sessionId to retrieve session from app's session storage
+  // In this example, getSessionFromStorage() must be provided by app
+  const session = await getSessionFromStorage(sessionId);
+
+  // return the list of currently active subscriptions for the shop
+  // referenced in the current session
+  const activeSubscriptions = await shopify.billing.subscriptions({
+    session,
+  });
+
+  // activeSubscriptions will be an array of subscription details, e.g.,
+  // [
+  //   {
+  //     "name": "My Active Subscription Charge",
+  //     "id": "gid://shopify/AppSubscription/1234567890",
+  //     "test": false
+  //   },
+  //   {
+  //     "name": "My Test Subscription Charge",
+  //     "id": "gid://shopify/AppSubscription/1234567890",
+  //     "test": true
+  //   },
+  // ],
+});
+```
+
+## Parameters
+
+Receives an object containing:
+
+### session
+
+`Session` | :exclamation: required
+
+The `Session` for the current request.
+
+## Return
+
+`ActiveSubscriptions`
+
+An object containing an array with subscription details, with the following shape:
+
+```ts
+{
+  activeSubscriptions: [
+    {
+      id: string;
+      name: string;
+      test: boolean;
+    },
+    {
+      id: string;
+      name: string;
+      test: boolean;
+    },
+    // ...
+  ];
+}
+```
+
+[Back to shopify.billing](./README.md)

--- a/docs/reference/billing/subscriptions.md
+++ b/docs/reference/billing/subscriptions.md
@@ -54,7 +54,7 @@ The `Session` for the current request.
 
 `ActiveSubscriptions`
 
-An object containing an array with subscription details, with the following shape:
+An object with an `activeSubscriptions` property containing an array with app subscription details, with the following shape:
 
 ```ts
 {

--- a/lib/billing/__tests__/cancel.test.ts
+++ b/lib/billing/__tests__/cancel.test.ts
@@ -63,10 +63,10 @@ describe('shopify.billing.cancel', () => {
         query: expect.stringContaining('appSubscriptionCancel'),
         variables: expect.objectContaining({
           id: subscriptionId,
-          prorate: false,
+          prorate: true,
         }),
       },
-    });
+    }).toMatchMadeHttpRequest();
   });
 
   test('throws a BillingError when an error occurs', async () => {

--- a/lib/billing/__tests__/cancel.test.ts
+++ b/lib/billing/__tests__/cancel.test.ts
@@ -1,0 +1,68 @@
+import {testConfig, queueMockResponses} from '../../__tests__/test-helper';
+import {Session} from '../../session/session';
+import {LATEST_API_VERSION} from '../../types';
+import {shopifyApi, Shopify, BillingInterval} from '../..';
+
+import * as Responses from './responses';
+
+const DOMAIN = 'test-shop.myshopify.io';
+const ACCESS_TOKEN = 'access-token';
+const GRAPHQL_BASE_REQUEST = {
+  method: 'POST',
+  domain: DOMAIN,
+  path: `/admin/api/${LATEST_API_VERSION}/graphql.json`,
+  headers: {'X-Shopify-Access-Token': ACCESS_TOKEN},
+};
+
+describe('shopify.billing.cancel', () => {
+  const session = new Session({
+    id: '1234',
+    shop: DOMAIN,
+    state: '1234',
+    isOnline: true,
+    accessToken: ACCESS_TOKEN,
+    scope: 'read_returns',
+  });
+
+  let shopify: Shopify;
+  beforeEach(() => {
+    shopify = shopifyApi({
+      ...testConfig,
+      billing: {
+        basic: {
+          amount: 5.0,
+          currencyCode: 'USD',
+          interval: BillingInterval.OneTime,
+        },
+      },
+    });
+  });
+
+  test('After a user cancels the check function should return', async () => {
+    queueMockResponses([Responses.CANCEL_RESPONSE]);
+
+    const {
+      data: {
+        currentAppInstallation: {activeSubscriptions},
+      },
+    } = Responses.EXISTING_SUBSCRIPTION_OBJECT;
+
+    const subscriptionId = activeSubscriptions[0].id;
+    const response = await shopify.billing.cancel({
+      session,
+      subscriptionId,
+    });
+
+    expect(response).toEqual(JSON.parse(Responses.CANCEL_RESPONSE));
+    expect({
+      ...GRAPHQL_BASE_REQUEST,
+      data: {
+        query: expect.stringContaining('appSubscriptionCancel'),
+        variables: expect.objectContaining({
+          id: subscriptionId,
+          prorate: false,
+        }),
+      },
+    });
+  });
+});

--- a/lib/billing/__tests__/responses.ts
+++ b/lib/billing/__tests__/responses.ts
@@ -155,6 +155,33 @@ export const CANCEL_RESPONSE = JSON.stringify({
   },
 });
 
+export const CANCEL_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
+  data: {
+    appSubscriptionCancel: {
+      appSubscription: {
+        id: 'gid://123',
+        name: PLAN_1,
+        test: true,
+      },
+      userErrors: ['Oops, something went wrong'],
+    },
+  },
+});
+
+export const CANCEL_RESPONSE_WITH_ERRORS = JSON.stringify({
+  data: {
+    appSubscriptionCancel: {
+      appSubscription: {
+        id: 'gid://123',
+        name: PLAN_1,
+        test: true,
+      },
+      userErrors: [],
+    },
+  },
+  errors: [{message: 'Oops, something went wrong'}],
+});
+
 export const SUBSCRIPTIONS_RESPONSE = JSON.stringify({
   data: {
     currentAppInstallation: {

--- a/lib/billing/__tests__/responses.ts
+++ b/lib/billing/__tests__/responses.ts
@@ -90,17 +90,21 @@ export const EXISTING_INACTIVE_ONE_TIME_PAYMENT = JSON.stringify({
   },
 });
 
-export const EXISTING_SUBSCRIPTION = JSON.stringify({
+export const EXISTING_SUBSCRIPTION_OBJECT = {
   data: {
     currentAppInstallation: {
       oneTimePurchases: {
         edges: [],
         pageInfo: {hasNextPage: false, endCursor: null},
       },
-      activeSubscriptions: [{name: PLAN_1, test: true}],
+      activeSubscriptions: [{id: 123, name: PLAN_1, test: true}],
     },
   },
-});
+};
+
+export const EXISTING_SUBSCRIPTION = JSON.stringify(
+  EXISTING_SUBSCRIPTION_OBJECT,
+);
 
 export const PURCHASE_ONE_TIME_RESPONSE = JSON.stringify({
   data: {
@@ -134,6 +138,19 @@ export const PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
     appSubscriptionCreate: {
       confirmationUrl: CONFIRMATION_URL,
       userErrors: ['Oops, something went wrong'],
+    },
+  },
+});
+
+export const CANCEL_RESPONSE = JSON.stringify({
+  data: {
+    appSubscriptionCancel: {
+      appSubscription: {
+        id: 123,
+        name: PLAN_1,
+        test: true,
+      },
+      userErrors: [],
     },
   },
 });

--- a/lib/billing/__tests__/responses.ts
+++ b/lib/billing/__tests__/responses.ts
@@ -97,7 +97,7 @@ export const EXISTING_SUBSCRIPTION_OBJECT = {
         edges: [],
         pageInfo: {hasNextPage: false, endCursor: null},
       },
-      activeSubscriptions: [{id: 123, name: PLAN_1, test: true}],
+      activeSubscriptions: [{id: 'gid://123', name: PLAN_1, test: true}],
     },
   },
 };
@@ -146,11 +146,19 @@ export const CANCEL_RESPONSE = JSON.stringify({
   data: {
     appSubscriptionCancel: {
       appSubscription: {
-        id: 123,
+        id: 'gid://123',
         name: PLAN_1,
         test: true,
       },
       userErrors: [],
+    },
+  },
+});
+
+export const SUBSCRIPTIONS_RESPONSE = JSON.stringify({
+  data: {
+    currentAppInstallation: {
+      activeSubscriptions: [{id: 'gid://123', name: PLAN_1, test: true}],
     },
   },
 });

--- a/lib/billing/__tests__/subscriptions.test.ts
+++ b/lib/billing/__tests__/subscriptions.test.ts
@@ -1,0 +1,58 @@
+import {testConfig, queueMockResponses} from '../../__tests__/test-helper';
+import {Session} from '../../session/session';
+import {LATEST_API_VERSION} from '../../types';
+import {shopifyApi, Shopify, BillingInterval} from '../..';
+
+import * as Responses from './responses';
+
+const DOMAIN = 'test-shop.myshopify.io';
+const ACCESS_TOKEN = 'access-token';
+const GRAPHQL_BASE_REQUEST = {
+  method: 'POST',
+  domain: DOMAIN,
+  path: `/admin/api/${LATEST_API_VERSION}/graphql.json`,
+  headers: {'X-Shopify-Access-Token': ACCESS_TOKEN},
+};
+
+describe('shopify.billing.subscriptions', () => {
+  const session = new Session({
+    id: '1234',
+    shop: DOMAIN,
+    state: '1234',
+    isOnline: true,
+    accessToken: ACCESS_TOKEN,
+    scope: 'read_returns',
+  });
+
+  let shopify: Shopify;
+  beforeEach(() => {
+    shopify = shopifyApi({
+      ...testConfig,
+      billing: {
+        basic: {
+          amount: 5.0,
+          currencyCode: 'USD',
+          interval: BillingInterval.OneTime,
+        },
+      },
+    });
+  });
+
+  test('Returns a list of subscriptions', async () => {
+    queueMockResponses([Responses.SUBSCRIPTIONS_RESPONSE]);
+
+    const response = await shopify.billing.subscriptions({
+      session,
+    });
+
+    expect(response).toEqual(
+      JSON.parse(Responses.SUBSCRIPTIONS_RESPONSE).data.currentAppInstallation,
+    );
+    expect({
+      ...GRAPHQL_BASE_REQUEST,
+      data: {
+        query: expect.stringContaining('currentAppInstallation'),
+      },
+    }).toMatchMadeHttpRequest();
+  });
+});

--- a/lib/billing/cancel.ts
+++ b/lib/billing/cancel.ts
@@ -1,0 +1,52 @@
+import {ConfigInterface} from '../base-types';
+import {graphqlClientClass} from '../clients/graphql/graphql_client';
+import {BillingError} from '../error';
+import {BillingCancelParams} from '../types';
+
+import {CancelResponse} from './types';
+
+const CANCEL_MUTATION = `
+  mutation appSubscriptionCancel($id: ID!, $returnUrl: String!) {
+    appSubscriptionCancel(id: $id) {
+      appSubscription {
+        id
+        name
+        test
+      }
+      userErrors {
+        field
+        message
+      }
+    }
+  }
+`;
+
+export function cancel(config: ConfigInterface) {
+  return async function (
+    subscriptionInfo: BillingCancelParams,
+  ): Promise<CancelResponse> {
+    const {session, subscriptionId, prorate = true} = subscriptionInfo;
+
+    const GraphqlClient = graphqlClientClass({config});
+    const client = new GraphqlClient({session});
+
+    const response = await client.query<CancelResponse>({
+      data: {
+        query: CANCEL_MUTATION,
+        variables: {
+          id: subscriptionId,
+          prorate,
+        },
+      },
+    });
+
+    if (response.body.errors?.length) {
+      throw new BillingError({
+        message: 'Error while canceling a subscription',
+        errorData: response.body.errors,
+      });
+    }
+
+    return response.body;
+  };
+}

--- a/lib/billing/cancel.ts
+++ b/lib/billing/cancel.ts
@@ -1,9 +1,8 @@
 import {ConfigInterface} from '../base-types';
 import {graphqlClientClass} from '../clients/graphql/graphql_client';
-import {BillingError} from '../error';
-import {BillingCancelParams} from '../types';
+import {BillingError, GraphqlQueryError} from '../error';
 
-import {CancelResponse} from './types';
+import {AppSubscription, BillingCancelParams, CancelResponse} from './types';
 
 const CANCEL_MUTATION = `
   mutation appSubscriptionCancel($id: ID!, $prorate: Boolean) {
@@ -24,29 +23,40 @@ const CANCEL_MUTATION = `
 export function cancel(config: ConfigInterface) {
   return async function (
     subscriptionInfo: BillingCancelParams,
-  ): Promise<CancelResponse> {
+  ): Promise<AppSubscription> {
     const {session, subscriptionId, prorate = true} = subscriptionInfo;
 
     const GraphqlClient = graphqlClientClass({config});
     const client = new GraphqlClient({session});
 
-    const response = await client.query<CancelResponse>({
-      data: {
-        query: CANCEL_MUTATION,
-        variables: {
-          id: subscriptionId,
-          prorate,
+    try {
+      const response = await client.query<CancelResponse>({
+        data: {
+          query: CANCEL_MUTATION,
+          variables: {
+            id: subscriptionId,
+            prorate,
+          },
         },
-      },
-    });
-
-    if (response.body.errors?.length) {
-      throw new BillingError({
-        message: 'Error while canceling a subscription',
-        errorData: response.body.errors,
       });
-    }
 
-    return response.body;
+      if (response.body.data.appSubscriptionCancel.userErrors.length) {
+        throw new BillingError({
+          message: 'Error while canceling a subscription',
+          errorData: response.body.data.appSubscriptionCancel.userErrors,
+        });
+      }
+
+      return response.body.data.appSubscriptionCancel.appSubscription;
+    } catch (error) {
+      if (error instanceof GraphqlQueryError) {
+        throw new BillingError({
+          message: error.message,
+          errorData: error.response?.errors,
+        });
+      } else {
+        throw error;
+      }
+    }
   };
 }

--- a/lib/billing/cancel.ts
+++ b/lib/billing/cancel.ts
@@ -6,8 +6,8 @@ import {BillingCancelParams} from '../types';
 import {CancelResponse} from './types';
 
 const CANCEL_MUTATION = `
-  mutation appSubscriptionCancel($id: ID!, $returnUrl: String!) {
-    appSubscriptionCancel(id: $id) {
+  mutation appSubscriptionCancel($id: ID!, $prorate: Boolean) {
+    appSubscriptionCancel(id: $id, prorate: $prorate) {
       appSubscription {
         id
         name

--- a/lib/billing/check.ts
+++ b/lib/billing/check.ts
@@ -102,6 +102,7 @@ const HAS_PAYMENTS_QUERY = `
   query appSubscription($endCursor: String) {
     currentAppInstallation {
       activeSubscriptions {
+        id
         name
         test
       }

--- a/lib/billing/check.ts
+++ b/lib/billing/check.ts
@@ -102,7 +102,6 @@ const HAS_PAYMENTS_QUERY = `
   query appSubscription($endCursor: String) {
     currentAppInstallation {
       activeSubscriptions {
-        id
         name
         test
       }

--- a/lib/billing/check.ts
+++ b/lib/billing/check.ts
@@ -1,4 +1,3 @@
-import {BillingCheckParams} from '../types';
 import {ConfigInterface} from '../base-types';
 import {
   graphqlClientClass,
@@ -6,7 +5,11 @@ import {
 } from '../clients/graphql/graphql_client';
 import {BillingError} from '../error';
 
-import {CurrentAppInstallation, CurrentAppInstallations} from './types';
+import {
+  BillingCheckParams,
+  CurrentAppInstallation,
+  CurrentAppInstallations,
+} from './types';
 
 interface CheckInternalParams {
   plans: string[];

--- a/lib/billing/index.ts
+++ b/lib/billing/index.ts
@@ -2,11 +2,13 @@ import {ConfigInterface} from '../base-types';
 
 import {check} from './check';
 import {request} from './request';
+import {cancel} from './cancel';
 
 export function shopifyBilling(config: ConfigInterface) {
   return {
     check: check(config),
     request: request(config),
+    cancel: cancel(config),
   };
 }
 

--- a/lib/billing/index.ts
+++ b/lib/billing/index.ts
@@ -3,12 +3,14 @@ import {ConfigInterface} from '../base-types';
 import {check} from './check';
 import {request} from './request';
 import {cancel} from './cancel';
+import {subscriptions} from './subscriptions';
 
 export function shopifyBilling(config: ConfigInterface) {
   return {
     check: check(config),
     request: request(config),
     cancel: cancel(config),
+    subscriptions: subscriptions(config),
   };
 }
 

--- a/lib/billing/request.ts
+++ b/lib/billing/request.ts
@@ -1,5 +1,5 @@
 import {ConfigInterface} from '../base-types';
-import {BillingInterval, BillingRequestParams} from '../types';
+import {BillingInterval} from '../types';
 import {BillingError} from '../error';
 import {buildEmbeddedAppUrl} from '../auth/get-embedded-app-url';
 import {
@@ -10,12 +10,13 @@ import {hashString} from '../../runtime/crypto';
 import {HashFormat} from '../../runtime/crypto/types';
 
 import {
-  RequestResponse,
-  RecurringPaymentResponse,
-  SinglePaymentResponse,
   BillingConfigSubscriptionPlan,
   BillingConfigOneTimePlan,
   BillingConfigUsagePlan,
+  BillingRequestParams,
+  RecurringPaymentResponse,
+  RequestResponse,
+  SinglePaymentResponse,
 } from './types';
 
 interface RequestInternalParams {

--- a/lib/billing/subscriptions.ts
+++ b/lib/billing/subscriptions.ts
@@ -1,0 +1,42 @@
+import {BillingError} from '../error';
+import {ConfigInterface} from '../base-types';
+import {graphqlClientClass} from '../clients/graphql/graphql_client';
+import {BillingSubscriptionParams} from '../types';
+
+import {ActiveSubscriptions, SubscriptionResponse} from './types';
+
+const SUBSCRIPTION_QUERY = `
+  query appSubscription {
+    currentAppInstallation {
+      activeSubscriptions {
+        id
+        name
+        test
+      }
+  }
+}
+`;
+
+export function subscriptions(config: ConfigInterface) {
+  return async function ({
+    session,
+  }: BillingSubscriptionParams): Promise<ActiveSubscriptions> {
+    if (!config.billing) {
+      throw new BillingError({
+        message: 'Attempted to look for purchases without billing configs',
+        errorData: [],
+      });
+    }
+
+    const GraphqlClient = graphqlClientClass({config});
+    const client = new GraphqlClient({session});
+
+    const response = await client.query<SubscriptionResponse>({
+      data: {
+        query: SUBSCRIPTION_QUERY,
+      },
+    });
+
+    return response.body.data.currentAppInstallation;
+  };
+}

--- a/lib/billing/subscriptions.ts
+++ b/lib/billing/subscriptions.ts
@@ -1,9 +1,12 @@
 import {BillingError} from '../error';
 import {ConfigInterface} from '../base-types';
 import {graphqlClientClass} from '../clients/graphql/graphql_client';
-import {BillingSubscriptionParams} from '../types';
 
-import {ActiveSubscriptions, SubscriptionResponse} from './types';
+import {
+  ActiveSubscriptions,
+  BillingSubscriptionParams,
+  SubscriptionResponse,
+} from './types';
 
 const SUBSCRIPTION_QUERY = `
   query appSubscription {

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -105,3 +105,23 @@ export interface SinglePaymentResponse {
   };
   errors?: string[];
 }
+
+// Ideally this is imported from core GQL types TODO:
+interface AppSubscription {
+  createdAt: string;
+  currentPeriodEnd: string;
+  id: string;
+  lineItems?: [any];
+  name: string;
+  returnUrl: string;
+  status: string;
+  test: boolean;
+  trialDays: number;
+}
+
+export interface CancelResponse {
+  data: {
+    appSubscription: AppSubscription;
+  };
+  errors?: string[];
+}

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -3,6 +3,7 @@ import {
   BillingReplacementBehavior,
   RecurringBillingIntervals,
 } from '../types';
+import {Session} from '../session/session';
 
 export interface BillingConfigPlan {
   amount: number;
@@ -51,14 +52,38 @@ export interface BillingConfig {
     | BillingConfigUsagePlan;
 }
 
-export interface ActiveSubscription {
+export interface BillingCheckParams {
+  session: Session;
+  plans: string[] | string;
+  isTest?: boolean;
+}
+
+export interface BillingRequestParams {
+  session: Session;
+  plan: string;
+  isTest?: boolean;
+  returnUrl?: string;
+}
+
+export interface BillingCancelParams {
+  session: Session;
+  subscriptionId: string;
+  prorate?: boolean;
+  isTest?: boolean;
+}
+
+export interface BillingSubscriptionParams {
+  session: Session;
+}
+
+export interface AppSubscription {
   id: string;
   name: string;
   test: boolean;
 }
 
 export interface ActiveSubscriptions {
-  activeSubscriptions: ActiveSubscription[];
+  activeSubscriptions: AppSubscription[];
 }
 
 interface OneTimePurchase {
@@ -111,11 +136,15 @@ export interface SubscriptionResponse {
   data: {
     currentAppInstallation: ActiveSubscriptions;
   };
+  errors?: string[];
 }
 
 export interface CancelResponse {
   data: {
-    currentAppInstallation: ActiveSubscriptions;
+    appSubscriptionCancel: {
+      appSubscription: AppSubscription;
+      userErrors: string[];
+    };
   };
   errors?: string[];
 }

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -51,12 +51,13 @@ export interface BillingConfig {
     | BillingConfigUsagePlan;
 }
 
-interface ActiveSubscription {
+export interface ActiveSubscription {
+  id: string;
   name: string;
   test: boolean;
 }
 
-interface ActiveSubscriptions {
+export interface ActiveSubscriptions {
   activeSubscriptions: ActiveSubscription[];
 }
 
@@ -106,22 +107,15 @@ export interface SinglePaymentResponse {
   errors?: string[];
 }
 
-// Ideally this is imported from core GQL types TODO:
-interface AppSubscription {
-  createdAt: string;
-  currentPeriodEnd: string;
-  id: string;
-  lineItems?: [any];
-  name: string;
-  returnUrl: string;
-  status: string;
-  test: boolean;
-  trialDays: number;
+export interface SubscriptionResponse {
+  data: {
+    currentAppInstallation: ActiveSubscriptions;
+  };
 }
 
 export interface CancelResponse {
   data: {
-    appSubscription: AppSubscription;
+    currentAppInstallation: ActiveSubscriptions;
   };
   errors?: string[];
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,6 +23,7 @@ export * from '../rest/types';
 export * from './types';
 export * from './base-types';
 export * from './auth/types';
+export * from './billing/types';
 export * from './clients/types';
 export * from './session/types';
 export * from './webhooks/types';

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -74,3 +74,10 @@ export interface BillingRequestParams {
   isTest?: boolean;
   returnUrl?: string;
 }
+
+export interface BillingCancelParams {
+  session: Session;
+  subscriptionId: number;
+  prorate?: boolean;
+  isTest?: boolean;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,5 +1,3 @@
-import {Session} from './session/session';
-
 export enum LogSeverity {
   Error,
   Warning,
@@ -60,28 +58,4 @@ export enum BillingReplacementBehavior {
   ApplyImmediately = 'APPLY_IMMEDIATELY',
   ApplyOnNextBillingCycle = 'APPLY_ON_NEXT_BILLING_CYCLE',
   Standard = 'STANDARD',
-}
-
-export interface BillingCheckParams {
-  session: Session;
-  plans: string[] | string;
-  isTest?: boolean;
-}
-
-export interface BillingRequestParams {
-  session: Session;
-  plan: string;
-  isTest?: boolean;
-  returnUrl?: string;
-}
-
-export interface BillingCancelParams {
-  session: Session;
-  subscriptionId: string;
-  prorate?: boolean;
-  isTest?: boolean;
-}
-
-export interface BillingSubscriptionParams {
-  session: Session;
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -77,7 +77,11 @@ export interface BillingRequestParams {
 
 export interface BillingCancelParams {
   session: Session;
-  subscriptionId: number;
+  subscriptionId: string;
   prorate?: boolean;
   isTest?: boolean;
+}
+
+export interface BillingSubscriptionParams {
+  session: Session;
 }


### PR DESCRIPTION
Fixes #771 

We allow for adding subscriptions and checking subscriptions in the JS Library however to cancel a subscription a thrid party developer would have to add their own graphql client and use the mutation directly.

### WHAT is this pull request doing?

Adding an unsubscribe function which handles canceling a subscription given the subscription ID and if it should be prorated or not. Prorate is defaulted to true to allow easier green path usage.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
