### PR TITLE
Remove support for Node 14, add Node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [14, 16, 18]
+        version: [16, 18, 20]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
-      # TODO Remove the --ignore-engines flag when we drop support for Node 14
       - name: Install
-        run: yarn install --ignore-engines
+        run: yarn install
       - name: Lint
         run: yarn lint
       - name: Test

--- a/lib/auth/decode-host.ts
+++ b/lib/auth/decode-host.ts
@@ -1,7 +1,3 @@
 export function decodeHost(host: string): string {
-  // eslint-disable-next-line no-warning-comments
-  // TODO Remove the Buffer.from call when dropping Node 14 support
-  return typeof atob === 'undefined'
-    ? Buffer.from(host, 'base64').toString()
-    : atob(host);
+  return atob(host);
 }

--- a/lib/auth/oauth/nonce.ts
+++ b/lib/auth/oauth/nonce.ts
@@ -1,13 +1,12 @@
 import {crypto} from '../../../runtime/crypto';
 
 export function nonce(): string {
+  const cryptoLib =
+    typeof (crypto as any)?.webcrypto === 'undefined'
+      ? crypto
+      : (crypto as any).webcrypto;
   const length = 15;
-
-  // eslint-disable-next-line no-warning-comments
-  // TODO Remove the randomBytes call when dropping Node 14 support
-  const bytes = crypto.getRandomValues
-    ? crypto.getRandomValues(new Uint8Array(length))
-    : (crypto as any).randomBytes(length);
+  const bytes = cryptoLib.getRandomValues(new Uint8Array(length));
 
   const nonce = bytes
     .map((byte: number) => {

--- a/runtime/crypto/utils.ts
+++ b/runtime/crypto/utils.ts
@@ -13,35 +13,26 @@ export async function createSHA256HMAC(
       ? crypto
       : (crypto as any).webcrypto;
 
-  // eslint-disable-next-line no-warning-comments
-  // TODO Make the subtle implementation the default when dropping Node 14 support
-  if (cryptoLib?.subtle) {
-    const enc = new TextEncoder();
-    const key = await cryptoLib.subtle.importKey(
-      'raw',
-      enc.encode(secret),
-      {
-        name: 'HMAC',
-        hash: {name: 'SHA-256'},
-      },
-      false,
-      ['sign'],
-    );
+  const enc = new TextEncoder();
+  const key = await cryptoLib.subtle.importKey(
+    'raw',
+    enc.encode(secret),
+    {
+      name: 'HMAC',
+      hash: {name: 'SHA-256'},
+    },
+    false,
+    ['sign'],
+  );
 
-    const signature = await cryptoLib.subtle.sign(
-      'HMAC',
-      key,
-      enc.encode(payload),
-    );
-    return returnFormat === HashFormat.Base64
-      ? asBase64(signature)
-      : asHex(signature);
-  }
-
-  return (cryptoLib as any)
-    .createHmac('sha256', secret)
-    .update(payload)
-    .digest(returnFormat);
+  const signature = await cryptoLib.subtle.sign(
+    'HMAC',
+    key,
+    enc.encode(payload),
+  );
+  return returnFormat === HashFormat.Base64
+    ? asBase64(signature)
+    : asHex(signature);
 }
 
 export function asHex(buffer: ArrayBuffer): string {


### PR DESCRIPTION
### WHY are these changes introduced?

This requires removing support for Node 14, which is EOL, which in turn means we can use newer crypto APIs.

### WHAT is this pull request doing?

Updates CI to not run Node 14, and add Node 20.
Updates various utility methods to drop Node 14 related crypto nuances.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
