### PR TITLE
Add `returnUrl` to billing request function

### DIFF
--- a/.changeset/forty-fireants-judge.md
+++ b/.changeset/forty-fireants-judge.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Added returnUrl as parameter to billing request function, improved returnUrl logic

--- a/docs/reference/billing/request.md
+++ b/docs/reference/billing/request.md
@@ -72,6 +72,12 @@ Which plan to create a charge for.
 
 If `true`, Shopify will not actually charge for this purchase.
 
+### returnUrl
+
+`string` | Defaults to embedded app's main page or hosted app's main page
+
+Which URL to redirect the merchant to after the charge is confirmed.
+
 ## Return
 
 `string`

--- a/lib/billing/__tests__/request_payment.test.ts
+++ b/lib/billing/__tests__/request_payment.test.ts
@@ -142,11 +142,37 @@ describe('shopify.billing.request', () => {
             ...GRAPHQL_BASE_REQUEST,
             data: {
               query: expect.stringContaining(config.mutationName),
-              variables: expect.objectContaining({test: isTest}),
+              variables: expect.objectContaining({
+                test: isTest,
+                returnUrl: 'https://test_host_name',
+              }),
             },
           }).toMatchMadeHttpRequest();
         }),
       );
+
+      test(`can request payment with returnUrl param`, async () => {
+        queueMockResponses([config.paymentResponse]);
+
+        const response = await shopify.billing.request({
+          session,
+          plan: Responses.PLAN_1,
+          isTest: true,
+          returnUrl: 'https://example.com',
+        });
+
+        expect(response).toBe(Responses.CONFIRMATION_URL);
+        expect({
+          ...GRAPHQL_BASE_REQUEST,
+          data: {
+            query: expect.stringContaining(config.mutationName),
+            variables: expect.objectContaining({
+              test: true,
+              returnUrl: 'https://example.com',
+            }),
+          },
+        }).toMatchMadeHttpRequest();
+      });
 
       test('defaults to test purchases', async () => {
         queueMockResponses([config.paymentResponse]);

--- a/lib/billing/request.ts
+++ b/lib/billing/request.ts
@@ -43,7 +43,7 @@ export function request(config: ConfigInterface) {
     session,
     plan,
     isTest = true,
-    returnUrl,
+    returnUrl: returnUrlParam,
   }: RequestParams): Promise<string> {
     if (!config.billing || !config.billing[plan]) {
       throw new BillingError({
@@ -61,9 +61,9 @@ export function request(config: ConfigInterface) {
 
     const appUrl = `${config.hostScheme}://${config.hostName}`;
 
-    // if provided a return URL, use it, otherwise use the embeded app URL or hosted app URL
-    const returnedUrl =
-      returnUrl || (config.isEmbeddedApp ? embeddedAppUrl : appUrl);
+    // if provided a return URL, use it, otherwise use the embedded app URL or hosted app URL
+    const returnUrl =
+      returnUrlParam || (config.isEmbeddedApp ? embeddedAppUrl : appUrl);
 
     const GraphqlClient = graphqlClientClass({config});
     const client = new GraphqlClient({session});
@@ -75,7 +75,7 @@ export function request(config: ConfigInterface) {
           billingConfig: billingConfig as BillingConfigOneTimePlan,
           plan,
           client,
-          returnUrl: returnedUrl,
+          returnUrl,
           isTest,
         });
         data = mutationOneTimeResponse.data.appPurchaseOneTimeCreate;
@@ -86,7 +86,7 @@ export function request(config: ConfigInterface) {
           billingConfig: billingConfig as BillingConfigUsagePlan,
           plan,
           client,
-          returnUrl: returnedUrl,
+          returnUrl,
           isTest,
         });
         data = mutationUsageResponse.data.appSubscriptionCreate;
@@ -97,7 +97,7 @@ export function request(config: ConfigInterface) {
           billingConfig: billingConfig as BillingConfigSubscriptionPlan,
           plan,
           client,
-          returnUrl: returnedUrl,
+          returnUrl,
           isTest,
         });
         data = mutationRecurringResponse.data.appSubscriptionCreate;

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -44,6 +44,7 @@ export interface RequestParams {
   session: Session;
   plan: string;
   isTest?: boolean;
+  returnUrl?: string;
 }
 
 interface ActiveSubscription {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #715 
Fixes #784 

When setting up a return Url to pass to Shopify, a hard coded value is used based on the `session.shop`.

This is sufficient for some, but not all use cases.

### WHAT is this pull request doing?

New logic is introduced so that a developer can specify an app URL to be redirected to after billing is confirmed by the merchant. This allows the developer to control the flow of the app.

It should also fix issues where a non-embedded app is getting redirected to an embedded app after billing confirmation.

If no returnUrl is passed, the unified admin URL is now used, which should eliminate an extra redirect.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
