### PR TITLE
Add support for Event topic names

### DIFF
--- a/.changeset/silly-rivers-fold.md
+++ b/.changeset/silly-rivers-fold.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Extend support for Event topic names

--- a/lib/webhooks/__tests__/process.test.ts
+++ b/lib/webhooks/__tests__/process.test.ts
@@ -79,6 +79,27 @@ describe('shopify.webhooks.process', () => {
     expect(blockingWebhookHandlerCalled).toBeTruthy();
   });
 
+  it('handles the request when a event topic is already registered', async () => {
+    const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
+    await shopify.webhooks.addHandlers({
+      DOMAIN_SUB_DOMAIN_SOMETHING_HAPPENED: handler,
+    });
+
+    const response = await request(app)
+      .post('/webhooks')
+      .set(
+        headers({
+          hmac: hmac(shopify.config.apiSecretKey, rawBody),
+          topic: 'domain.sub_domain.something_happened',
+        }),
+      )
+      .send(rawBody)
+      .expect(StatusCode.Ok);
+
+    expect(response.body.data.errorThrown).toBeFalsy();
+    expect(blockingWebhookHandlerCalled).toBeTruthy();
+  });
+
   it('handles lower case headers', async () => {
     const handler = {...HTTP_HANDLER, callback: blockingWebhookHandler};
     shopify.webhooks.addHandlers({PRODUCTS_CREATE: handler});

--- a/lib/webhooks/__tests__/registry.test.ts
+++ b/lib/webhooks/__tests__/registry.test.ts
@@ -73,15 +73,22 @@ describe('shopify.webhooks.addHandlers', () => {
     }).toThrow('Can only add multiple handlers when deliveryMethod is Http.');
   });
 
-  it('adds handler with lowercase/slash format to the webhook registry', async () => {
-    shopify.webhooks.addHandlers({
+  it('adds handler with lowercase/slash-period format to the webhook registry', async () => {
+    const handler3: HttpWebhookHandler = {
+      ...HTTP_HANDLER,
+      callback: jest.fn().mockImplementation(genericWebhookHandler),
+    };
+
+    await shopify.webhooks.addHandlers({
       'products/create': handler1,
       'products/delete': handler2,
+      'domain.sub_domain.something_happened': handler3,
     });
-    expect(shopify.webhooks.getTopicsAdded()).toHaveLength(2);
+    expect(shopify.webhooks.getTopicsAdded()).toHaveLength(3);
     expect(shopify.webhooks.getTopicsAdded()).toEqual([
       'PRODUCTS_CREATE',
       'PRODUCTS_DELETE',
+      'DOMAIN_SUB_DOMAIN_SOMETHING_HAPPENED',
     ]);
   });
 });

--- a/lib/webhooks/registry.ts
+++ b/lib/webhooks/registry.ts
@@ -14,7 +14,7 @@ export function registry(): WebhookRegistry {
 }
 
 export function topicForStorage(topic: string): string {
-  return topic.toUpperCase().replace(/\//g, '_');
+  return topic.toUpperCase().replace(/\/|\./g, '_');
 }
 
 export function addHandlers(


### PR DESCRIPTION
### WHY are these changes introduced?

Allows more variety of webhook topic names.

Event topic names will allow period as a separator and these need to be translated to GraphQL valid ENUM values.

### WHAT is this pull request doing?

Transform period to underscore

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [X] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
