### PR TITLE
Add deprecation notice for Node 14 support

### DIFF
--- a/.changeset/late-wolves-invent.md
+++ b/.changeset/late-wolves-invent.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Add deprecation notice for removal of Node 14 support from next major release

--- a/lib/__tests__/initialization.test.ts
+++ b/lib/__tests__/initialization.test.ts
@@ -48,17 +48,13 @@ describe('shopifyApi', () => {
       testRuntimeString = version;
       shopify = shopifyApi(testConfig);
       expect(abstractRuntimeString()).toStrictEqual(version);
-      if (deprecated) {
-        expect(shopify.config.logger.log).toHaveBeenLastCalledWith(
-          LogSeverity.Warning,
-          expect.stringContaining('[Deprecated | 8.0.0] Support for'),
-        );
-      } else {
-        expect(shopify.config.logger.log).not.toHaveBeenLastCalledWith(
-          LogSeverity.Warning,
-          expect.stringContaining('[Deprecated | 8.0.0] Support for'),
-        );
-      }
+      const localExpect = deprecated
+        ? expect(shopify.config.logger.log)
+        : expect(shopify.config.logger.log).not;
+      localExpect.toHaveBeenLastCalledWith(
+        LogSeverity.Warning,
+        expect.stringContaining('[Deprecated | 8.0.0] Support for'),
+      );
     });
   });
 });

--- a/lib/__tests__/initialization.test.ts
+++ b/lib/__tests__/initialization.test.ts
@@ -1,0 +1,60 @@
+import {LogSeverity} from '../types';
+import {shopifyApi, Shopify} from '..';
+// import {abstractRuntimeString} from '../../runtime/platform';
+
+import {testConfig} from './test-helper';
+
+let shopify: Shopify;
+
+// need this as the runtimeString is "Mock Adapter"
+jest.mock('../../runtime/platform', () => ({
+  abstractRuntimeString: jest.fn(() => 'Node'),
+}));
+
+describe('shopifyApi', () => {
+  afterAll(() => {
+    jest.resetModules();
+  });
+
+  [
+    {
+      version: 'v14.0.0',
+      deprecated: true,
+    },
+    {
+      version: 'v16.0.0',
+      deprecated: false,
+    },
+    {
+      version: 'v18.0.0',
+      deprecated: false,
+    },
+    {
+      version: 'v20.0.0',
+      deprecated: false,
+    },
+  ].forEach(({version, deprecated}) => {
+    test(`${
+      deprecated ? 'logs' : 'does not log'
+    } deprecation if Node ${version}`, () => {
+      const originalProcess = process;
+      Object.defineProperty(process, 'version', {
+        value: version,
+      });
+      expect(process.version).toEqual(version);
+      shopify = shopifyApi(testConfig);
+      if (deprecated) {
+        expect(shopify.config.logger.log).toHaveBeenLastCalledWith(
+          LogSeverity.Warning,
+          expect.stringContaining('[Deprecated | 8.0.0] Support for'),
+        );
+      } else {
+        expect(shopify.config.logger.log).not.toHaveBeenLastCalledWith(
+          LogSeverity.Warning,
+          expect.stringContaining('[Deprecated | 8.0.0] Support for'),
+        );
+      }
+      process = originalProcess;
+    });
+  });
+});

--- a/lib/__tests__/initialization.test.ts
+++ b/lib/__tests__/initialization.test.ts
@@ -1,14 +1,14 @@
 import {LogSeverity} from '../types';
 import {shopifyApi, Shopify} from '..';
-// import {abstractRuntimeString} from '../../runtime/platform';
+import {abstractRuntimeString} from '../../runtime/platform';
 
 import {testConfig} from './test-helper';
 
 let shopify: Shopify;
+let testRuntimeString = '';
 
-// need this as the runtimeString is "Mock Adapter"
 jest.mock('../../runtime/platform', () => ({
-  abstractRuntimeString: jest.fn(() => 'Node'),
+  abstractRuntimeString: jest.fn(() => testRuntimeString),
 }));
 
 describe('shopifyApi', () => {
@@ -18,31 +18,36 @@ describe('shopifyApi', () => {
 
   [
     {
-      version: 'v14.0.0',
+      version: 'Mock Adapter',
+      deprecated: false,
+    },
+    {
+      version: 'Cloudflare Worker',
+      deprecated: false,
+    },
+    {
+      version: 'Node v14.0.0',
       deprecated: true,
     },
     {
-      version: 'v16.0.0',
+      version: 'Node v16.0.0',
       deprecated: false,
     },
     {
-      version: 'v18.0.0',
+      version: 'Node v18.0.0',
       deprecated: false,
     },
     {
-      version: 'v20.0.0',
+      version: 'Node v20.0.0',
       deprecated: false,
     },
   ].forEach(({version, deprecated}) => {
     test(`${
       deprecated ? 'logs' : 'does not log'
-    } deprecation if Node ${version}`, () => {
-      const originalProcess = process;
-      Object.defineProperty(process, 'version', {
-        value: version,
-      });
-      expect(process.version).toEqual(version);
+    } deprecation if ${version}`, () => {
+      testRuntimeString = version;
       shopify = shopifyApi(testConfig);
+      expect(abstractRuntimeString()).toStrictEqual(version);
       if (deprecated) {
         expect(shopify.config.logger.log).toHaveBeenLastCalledWith(
           LogSeverity.Warning,
@@ -54,7 +59,6 @@ describe('shopifyApi', () => {
           expect.stringContaining('[Deprecated | 8.0.0] Support for'),
         );
       }
-      process = originalProcess;
     });
   });
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -77,8 +77,12 @@ export function shopifyApi<T extends ShopifyRestResources>(
     )
     .catch((err) => console.log(err));
 
-  const isNode = abstractRuntimeString().startsWith('Node');
-  if (isNode && compare(process.version, '16.0.0', '<')) {
+  const nodeVersionMatches = abstractRuntimeString().match(
+    /(Node) (v\d+\.\d+\.\d+)/,
+  );
+  const isNode = nodeVersionMatches && nodeVersionMatches[1] === 'Node';
+  const nodeVersion = nodeVersionMatches ? nodeVersionMatches[2] : '';
+  if (isNode && compare(nodeVersion, '16.0.0', '<')) {
     shopify.logger.deprecated(
       '8.0.0',
       `Support for ${abstractRuntimeString()} will be removed`,

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,5 @@
+import {compare} from 'compare-versions';
+
 import {loadRestResources} from '../rest/load-rest-resources';
 import {ShopifyRestResources} from '../rest/types';
 import {abstractRuntimeString} from '../runtime/platform';
@@ -74,6 +76,14 @@ export function shopifyApi<T extends ShopifyRestResources>(
       `version ${SHOPIFY_API_LIBRARY_VERSION}, environment ${abstractRuntimeString()}`,
     )
     .catch((err) => console.log(err));
+
+  const isNode = abstractRuntimeString().startsWith('Node');
+  if (isNode && compare(process.version, '16.0.0', '<')) {
+    shopify.logger.deprecated(
+      '8.0.0',
+      `Support for ${abstractRuntimeString()} will be removed`,
+    );
+  }
 
   return shopify;
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -85,7 +85,7 @@ export function shopifyApi<T extends ShopifyRestResources>(
   if (isNode && compare(nodeVersion, '16.0.0', '<')) {
     shopify.logger.deprecated(
       '8.0.0',
-      `Support for ${abstractRuntimeString()} will be removed`,
+      `Support for ${abstractRuntimeString()} will be removed - please upgrade to Node v16.0.0 or higher.`,
     );
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Removing Node 14 support is a breaking change.

### WHAT is this pull request doing?

This change adds a deprecation notice indicating that Node 14 support will be removed in the next major version.  Allows us to release a patch/minor version with other fixes first.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
