### PR TITLE
Restoring REST resources for 2022-04, fixes other resources

### DIFF
--- a/.changeset/sour-paws-tap.md
+++ b/.changeset/sour-paws-tap.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Restoring REST resources for 2022-04, updates to certain resources for other API versions

--- a/rest/admin/2022-04/order_risk.ts
+++ b/rest/admin/2022-04/order_risk.ts
@@ -100,6 +100,6 @@ export class OrderRisk extends Base {
   public message: string | null;
   public order_id: number | null;
   public recommendation: string | null;
-  public score: number | null;
+  public score: string | null;
   public source: string | null;
 }

--- a/rest/admin/2022-07/order_risk.ts
+++ b/rest/admin/2022-07/order_risk.ts
@@ -100,6 +100,6 @@ export class OrderRisk extends Base {
   public message: string | null;
   public order_id: number | null;
   public recommendation: string | null;
-  public score: number | null;
+  public score: string | null;
   public source: string | null;
 }

--- a/rest/admin/2022-10/order_risk.ts
+++ b/rest/admin/2022-10/order_risk.ts
@@ -100,6 +100,6 @@ export class OrderRisk extends Base {
   public message: string | null;
   public order_id: number | null;
   public recommendation: string | null;
-  public score: number | null;
+  public score: string | null;
   public source: string | null;
 }

--- a/rest/admin/2023-01/order_risk.ts
+++ b/rest/admin/2023-01/order_risk.ts
@@ -100,6 +100,6 @@ export class OrderRisk extends Base {
   public message: string | null;
   public order_id: number | null;
   public recommendation: string | null;
-  public score: number | null;
+  public score: string | null;
   public source: string | null;
 }

--- a/rest/admin/2023-04/order_risk.ts
+++ b/rest/admin/2023-04/order_risk.ts
@@ -100,6 +100,6 @@ export class OrderRisk extends Base {
   public message: string | null;
   public order_id: number | null;
   public recommendation: string | null;
-  public score: number | null;
+  public score: string | null;
   public source: string | null;
 }

--- a/rest/admin/__tests__/2022-04/order_risk.test.ts
+++ b/rest/admin/__tests__/2022-04/order_risk.test.ts
@@ -31,13 +31,13 @@ describe('OrderRisk resource', () => {
   session.accessToken = 'this_is_a_test_token';
 
   it('test_1', async () => {
-    queueMockResponse(JSON.stringify({"risk": {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
+    queueMockResponse(JSON.stringify({"risk": {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
 
     const order_risk = new shopify.rest.OrderRisk({session: session});
     order_risk.order_id = 450789469;
     order_risk.message = "This order came from an anonymous proxy";
     order_risk.recommendation = "cancel";
-    order_risk.score = 1.0;
+    order_risk.score = "1.0";
     order_risk.source = "External";
     order_risk.cause_cancel = true;
     order_risk.display = true;
@@ -49,12 +49,12 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2022-04/orders/450789469/risks.json',
       query: '',
       headers,
-      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": 1.0, "source": "External", "cause_cancel": true, "display": true} }
+      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": "1.0", "source": "External", "cause_cancel": true, "display": true} }
     }).toMatchMadeHttpRequest();
   });
 
   it('test_2', async () => {
-    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
+    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
 
     await shopify.rest.OrderRisk.all({
       session: session,
@@ -100,7 +100,7 @@ describe('OrderRisk resource', () => {
     order_risk.recommendation = "accept";
     order_risk.source = "External";
     order_risk.cause_cancel = false;
-    order_risk.score = 0.0;
+    order_risk.score = "0.0";
     await order_risk.save({});
 
     expect({
@@ -109,7 +109,7 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2022-04/orders/450789469/risks/284138680.json',
       query: '',
       headers,
-      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": 0.0} }
+      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": "0.0"} }
     }).toMatchMadeHttpRequest();
   });
 

--- a/rest/admin/__tests__/2022-07/order_risk.test.ts
+++ b/rest/admin/__tests__/2022-07/order_risk.test.ts
@@ -31,13 +31,13 @@ describe('OrderRisk resource', () => {
   session.accessToken = 'this_is_a_test_token';
 
   it('test_1', async () => {
-    queueMockResponse(JSON.stringify({"risk": {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
+    queueMockResponse(JSON.stringify({"risk": {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
 
     const order_risk = new shopify.rest.OrderRisk({session: session});
     order_risk.order_id = 450789469;
     order_risk.message = "This order came from an anonymous proxy";
     order_risk.recommendation = "cancel";
-    order_risk.score = 1.0;
+    order_risk.score = "1.0";
     order_risk.source = "External";
     order_risk.cause_cancel = true;
     order_risk.display = true;
@@ -49,12 +49,12 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2022-07/orders/450789469/risks.json',
       query: '',
       headers,
-      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": 1.0, "source": "External", "cause_cancel": true, "display": true} }
+      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": "1.0", "source": "External", "cause_cancel": true, "display": true} }
     }).toMatchMadeHttpRequest();
   });
 
   it('test_2', async () => {
-    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
+    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
 
     await shopify.rest.OrderRisk.all({
       session: session,
@@ -100,7 +100,7 @@ describe('OrderRisk resource', () => {
     order_risk.recommendation = "accept";
     order_risk.source = "External";
     order_risk.cause_cancel = false;
-    order_risk.score = 0.0;
+    order_risk.score = "0.0";
     await order_risk.save({});
 
     expect({
@@ -109,7 +109,7 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2022-07/orders/450789469/risks/284138680.json',
       query: '',
       headers,
-      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": 0.0} }
+      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": "0.0"} }
     }).toMatchMadeHttpRequest();
   });
 

--- a/rest/admin/__tests__/2022-10/order_risk.test.ts
+++ b/rest/admin/__tests__/2022-10/order_risk.test.ts
@@ -31,13 +31,13 @@ describe('OrderRisk resource', () => {
   session.accessToken = 'this_is_a_test_token';
 
   it('test_1', async () => {
-    queueMockResponse(JSON.stringify({"risk": {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
+    queueMockResponse(JSON.stringify({"risk": {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
 
     const order_risk = new shopify.rest.OrderRisk({session: session});
     order_risk.order_id = 450789469;
     order_risk.message = "This order came from an anonymous proxy";
     order_risk.recommendation = "cancel";
-    order_risk.score = 1.0;
+    order_risk.score = "1.0";
     order_risk.source = "External";
     order_risk.cause_cancel = true;
     order_risk.display = true;
@@ -49,12 +49,12 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2022-10/orders/450789469/risks.json',
       query: '',
       headers,
-      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": 1.0, "source": "External", "cause_cancel": true, "display": true} }
+      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": "1.0", "source": "External", "cause_cancel": true, "display": true} }
     }).toMatchMadeHttpRequest();
   });
 
   it('test_2', async () => {
-    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
+    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
 
     await shopify.rest.OrderRisk.all({
       session: session,
@@ -100,7 +100,7 @@ describe('OrderRisk resource', () => {
     order_risk.recommendation = "accept";
     order_risk.source = "External";
     order_risk.cause_cancel = false;
-    order_risk.score = 0.0;
+    order_risk.score = "0.0";
     await order_risk.save({});
 
     expect({
@@ -109,7 +109,7 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2022-10/orders/450789469/risks/284138680.json',
       query: '',
       headers,
-      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": 0.0} }
+      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": "0.0"} }
     }).toMatchMadeHttpRequest();
   });
 

--- a/rest/admin/__tests__/2023-01/order_risk.test.ts
+++ b/rest/admin/__tests__/2023-01/order_risk.test.ts
@@ -31,13 +31,13 @@ describe('OrderRisk resource', () => {
   session.accessToken = 'this_is_a_test_token';
 
   it('test_1', async () => {
-    queueMockResponse(JSON.stringify({"risk": {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
+    queueMockResponse(JSON.stringify({"risk": {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
 
     const order_risk = new shopify.rest.OrderRisk({session: session});
     order_risk.order_id = 450789469;
     order_risk.message = "This order came from an anonymous proxy";
     order_risk.recommendation = "cancel";
-    order_risk.score = 1.0;
+    order_risk.score = "1.0";
     order_risk.source = "External";
     order_risk.cause_cancel = true;
     order_risk.display = true;
@@ -49,12 +49,12 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2023-01/orders/450789469/risks.json',
       query: '',
       headers,
-      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": 1.0, "source": "External", "cause_cancel": true, "display": true} }
+      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": "1.0", "source": "External", "cause_cancel": true, "display": true} }
     }).toMatchMadeHttpRequest();
   });
 
   it('test_2', async () => {
-    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
+    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
 
     await shopify.rest.OrderRisk.all({
       session: session,
@@ -100,7 +100,7 @@ describe('OrderRisk resource', () => {
     order_risk.recommendation = "accept";
     order_risk.source = "External";
     order_risk.cause_cancel = false;
-    order_risk.score = 0.0;
+    order_risk.score = "0.0";
     await order_risk.save({});
 
     expect({
@@ -109,7 +109,7 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2023-01/orders/450789469/risks/284138680.json',
       query: '',
       headers,
-      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": 0.0} }
+      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": "0.0"} }
     }).toMatchMadeHttpRequest();
   });
 

--- a/rest/admin/__tests__/2023-04/order_risk.test.ts
+++ b/rest/admin/__tests__/2023-04/order_risk.test.ts
@@ -31,13 +31,13 @@ describe('OrderRisk resource', () => {
   session.accessToken = 'this_is_a_test_token';
 
   it('test_1', async () => {
-    queueMockResponse(JSON.stringify({"risk": {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
+    queueMockResponse(JSON.stringify({"risk": {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}}));
 
     const order_risk = new shopify.rest.OrderRisk({session: session});
     order_risk.order_id = 450789469;
     order_risk.message = "This order came from an anonymous proxy";
     order_risk.recommendation = "cancel";
-    order_risk.score = 1.0;
+    order_risk.score = "1.0";
     order_risk.source = "External";
     order_risk.cause_cancel = true;
     order_risk.display = true;
@@ -49,12 +49,12 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2023-04/orders/450789469/risks.json',
       query: '',
       headers,
-      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": 1.0, "source": "External", "cause_cancel": true, "display": true} }
+      data: { "risk": {"message": "This order came from an anonymous proxy", "recommendation": "cancel", "score": "1.0", "source": "External", "cause_cancel": true, "display": true} }
     }).toMatchMadeHttpRequest();
   });
 
   it('test_2', async () => {
-    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151490, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
+    queueMockResponse(JSON.stringify({"risks": [{"id": 284138680, "order_id": 450789469, "checkout_id": null, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order was placed from a proxy IP", "merchant_message": "This order was placed from a proxy IP"}, {"id": 1029151489, "order_id": 450789469, "checkout_id": 901414060, "source": "External", "score": "1.0", "recommendation": "cancel", "display": true, "cause_cancel": true, "message": "This order came from an anonymous proxy", "merchant_message": "This order came from an anonymous proxy"}]}));
 
     await shopify.rest.OrderRisk.all({
       session: session,
@@ -100,7 +100,7 @@ describe('OrderRisk resource', () => {
     order_risk.recommendation = "accept";
     order_risk.source = "External";
     order_risk.cause_cancel = false;
-    order_risk.score = 0.0;
+    order_risk.score = "0.0";
     await order_risk.save({});
 
     expect({
@@ -109,7 +109,7 @@ describe('OrderRisk resource', () => {
       path: '/admin/api/2023-04/orders/450789469/risks/284138680.json',
       query: '',
       headers,
-      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": 0.0} }
+      data: { "risk": {"message": "After further review, this is a legitimate order", "recommendation": "accept", "source": "External", "cause_cancel": false, "score": "0.0"} }
     }).toMatchMadeHttpRequest();
   });
 


### PR DESCRIPTION
### WHAT is this pull request doing?

Deprecation of API Version 2022-04 is delayed until June 2023. Fixed various typing errors related to string properties that are numbers, per the API.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
