### PR TITLE
Update check and request to return objects with id

### DIFF
--- a/.changeset/curly-squids-switch.md
+++ b/.changeset/curly-squids-switch.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Add optional parameter to `billing.check` and `billing.request` to modify return value to be a more detailed object.

--- a/.changeset/tall-rings-knock.md
+++ b/.changeset/tall-rings-knock.md
@@ -10,7 +10,7 @@ Usage:
 const canceledSubscription = await shopify.billing.cancel({
   session,
   subscriptionId,
-})
+});
 ```
 
 See [Billing Guide](https://github.com/shopify/shopify-api-js/blob/main/docs/guides/billing.md) for more details.

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -27,7 +27,7 @@ const shopify = shopifyApi({
         value: {
           amount: 10,
         },
-      }
+      },
     },
   },
 });
@@ -37,39 +37,40 @@ This setting is a collection of billing plans. Each billing plan allows the foll
 
 ### One Time Billing Plans
 
-| Parameter      | Type       | Required? | Default Value | Notes                                                      |
-| -------------- | ---------- | :-------: | :-----------: | ---------------------------------------------------------- |
-| `interval`     | `ONE_TIME` |    Yes    |       -       | `BillingInterval.OneTime` value                            |
-| `amount`       | `number`   |    Yes    |       -       | The amount to charge                                       |
+| Parameter      | Type       | Required? | Default Value | Notes                                                               |
+| -------------- | ---------- | :-------: | :-----------: | ------------------------------------------------------------------- |
+| `interval`     | `ONE_TIME` |    Yes    |       -       | `BillingInterval.OneTime` value                                     |
+| `amount`       | `number`   |    Yes    |       -       | The amount to charge                                                |
 | `currencyCode` | `string`   |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup> |
 
 ### Recurring Billing Plans
 
-| Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                        |
-| --------------------- | ---------------------------- | :-------: | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `interval`            | `EVERY_30_DAYS`, `ANNUAL`    |    Yes    |       -       | `BillingInterval.Every30Days`, `BillingInterval.Annual` value                                                                                                |
-| `amount`              | `number`                     |    Yes    |       -       | The amount to charge                                                                                                                                         |
-| `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup>                                                                                                   |
-| `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                |
-| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information. |
-| `discount.durationLimitInIntervals` | `number` | No | - | The number of billing intervals to apply the discount for. See [the reference](https://shopify.dev/docs/apps/billing/purchase-adjustments/subscription-discounts) for more information |
-| `discount.value.amount` | `number` | No | - | The amount of the discount in the currency that the merchant is being billed in. |
-| `discount.value.percentage` | `number` | No | - | The percentage value of the discount. |
+| Parameter                           | Type                         | Required? | Default Value | Notes                                                                                                                                                                                  |
+| ----------------------------------- | ---------------------------- | :-------: | :-----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interval`                          | `EVERY_30_DAYS`, `ANNUAL`    |    Yes    |       -       | `BillingInterval.Every30Days`, `BillingInterval.Annual` value                                                                                                                          |
+| `amount`                            | `number`                     |    Yes    |       -       | The amount to charge                                                                                                                                                                   |
+| `currencyCode`                      | `string`                     |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup>                                                                                                                    |
+| `trialDays`                         | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                                          |
+| `replacementBehavior`               | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information.                       |
+| `discount.durationLimitInIntervals` | `number`                     |    No     |       -       | The number of billing intervals to apply the discount for. See [the reference](https://shopify.dev/docs/apps/billing/purchase-adjustments/subscription-discounts) for more information |
+| `discount.value.amount`             | `number`                     |    No     |       -       | The amount of the discount in the currency that the merchant is being billed in.                                                                                                       |
+| `discount.value.percentage`         | `number`                     |    No     |       -       | The percentage value of the discount.                                                                                                                                                  |
 
 > **Note** `discount.value` can only include either `amount` or `percentage` but not both.
 
 ### Usage Billing Plans
 
-| Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                        |
-| --------------------- | ---------------------------- | :-------: | :-----------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `interval`            | `USAGE`                      |    Yes    |       -       | `BillingInterval.Usage`                                                                                                                                      |
-| `amount`              | `number`                     |    Yes    |       -       | The maximum amount the merchant will be charged                                                                                                              |
-| `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup>                                                                                                   |
-| `usageTerms`          | `string`                     |    Yes    |       -       | These terms stipulate the pricing model for the charges that an app creates.                                                                                 |
-| `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                |
+| Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                            |
+| --------------------- | ---------------------------- | :-------: | :-----------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interval`            | `USAGE`                      |    Yes    |       -       | `BillingInterval.Usage`                                                                                                                                          |
+| `amount`              | `number`                     |    Yes    |       -       | The maximum amount the merchant will be charged                                                                                                                  |
+| `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup>                                                                                              |
+| `usageTerms`          | `string`                     |    Yes    |       -       | These terms stipulate the pricing model for the charges that an app creates.                                                                                     |
+| `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                    |
 | `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information. |
 
 1. Prior to `ApiVersion.April23` the currency code must be `USD`.
+
 ## When should the app check for payment?
 
 As mentioned above, billing requires a session to access the API, which means that the app must actually be installed before it can request payment.
@@ -84,7 +85,9 @@ If you're gating access to the entire app, you should check for billing:
 
 ## Canceling a subscription
 
-With the `cancel` method you'll be able to cancel a single subscription. First, you'll need to obtain the id for the subscription you wish to cancel, using the `subscriptions` method.
+With the `cancel` method you'll be able to cancel a single subscription. First, you'll need to obtain the id for the subscription you wish to cancel. You can use the `subscriptions` method to obtain a list of current subscriptions.
+
+As of version `7.3.0`, the `check` and `request` methods can take an optional `returnObject` parameter that modifies the return value to be an object that will include the payment/subscription plan `id`'s, among other data. This allows the app to save the id's for a future call to `cancel`. See the [billing reference](../reference/billing/README.md) for more details.
 
 ```js
 const activeSubscriptions = await shopify.api.billing.subscriptions({
@@ -107,12 +110,12 @@ The call to `cancel` will return an `AppSubscription` object, containing the det
 
 ```js
 // using the example activeSubscriptions response above...
-const subscriptionId = activeSubscriptions[0].id;  // "gid://shopify/AppSubscription/1234567890"
+const subscriptionId = activeSubscriptions[0].id; // "gid://shopify/AppSubscription/1234567890"
 const canceledSubscription = await shopify.billing.cancel({
   session,
   subscriptionId,
-  prorate: true,  // Whether to issue prorated credits for the unused portion of the app subscription. Defaults to true.
-})
+  prorate: true, // Whether to issue prorated credits for the unused portion of the app subscription. Defaults to true.
+});
 
 // canceledSubscription will have the following shape:
 // {

--- a/docs/reference/billing/check.md
+++ b/docs/reference/billing/check.md
@@ -4,7 +4,7 @@ Checks if a payment exists for any of the given plans, by querying the Shopify A
 
 > **Note**: Depending on the number of requests your app handles, you might want to cache a merchant's payment status, but you should periodically call this method to ensure you're blocking unpaid access.
 
-## Example
+## Example (not using return objects)
 
 ```ts
 // This can happen at any point after the merchant goes through the OAuth process, as long as there is a session object
@@ -43,6 +43,71 @@ async function billingMiddleware(req, res, next) {
 app.use('/requires-payment/*', billingMiddleware);
 ```
 
+## Example (using return objects)
+
+As of version `7.3.0`, `check` can also receive an optional `returnObject` parameter that adjusts what is returned by the method.
+
+```ts
+// This can happen at any point after the merchant goes through the OAuth process, as long as there is a session object
+// The session can be retrieved from storage using the session id returned from shopify.session.getCurrentId
+async function billingMiddleware(req, res, next) {
+  const sessionId = shopify.session.getCurrentId({
+    isOnline: true,
+    rawRequest: req,
+    rawResponse: res,
+  });
+
+  // use sessionId to retrieve session from app's session storage
+  // In this example, getSessionFromStorage() must be provided by app
+  const session = await getSessionFromStorage(sessionId);
+
+  const payments = await shopify.billing.check({
+    session,
+    plans: ['My billing plan'],
+    isTest: true,
+    returnObject: true,
+  });
+
+  // With `returnObject` set to `true, `payments` now has the following shape:
+  // {
+  //   hasActivePayment: boolean;
+  //   oneTimePurchases: OneTimePurchase[];
+  //   appSubscriptions: AppSubscription[];
+  // }
+  //
+  // OneTimePurchase has the following properties:
+  // {
+  //   id: string;
+  //   name: string;
+  //   test: boolean;
+  //   status: string;
+  // }
+
+  // AppSubscription has the properties...
+  // {
+  //   id: string;
+  //   name: string;
+  //   test: boolean;
+  // }
+
+  if (payments.hasActivePayment) {
+    next();
+  } else {
+    // Either request payment now (if single plan) or redirect to plan selection page (if multiple plans available), e.g.
+    const billingResponse = await shopify.billing.request({
+      session,
+      plan: 'My billing plan',
+      isTest: true,
+      returnObject: true,
+    });
+
+    res.redirect(billingResponse.confirmationUrl);
+  }
+}
+
+app.use('/requires-payment/*', billingMiddleware);
+```
+
 ## Parameters
 
 Receives an object containing:
@@ -65,10 +130,53 @@ Which plans to look for.
 
 Whether to look for test purchases only.
 
+### returnObject
+
+`boolean` | Defaults to `false`
+
+Whether to return `true`/`false` to indicate that there's a valid payment, or to return a more detailed object (see below).
+
 ## Return
+
+### if `returnObject` parameter is `false` (default)
 
 `Promise<boolean>`
 
 `true` if there is a payment for any of the given plans, and `false` otherwise.
+
+### if `returnObject` parameter is `true`
+
+`Promise<BillingCheckResponseObject>`
+
+`BillingCheckResponseObject` has the following shape:
+
+```ts
+{
+  hasActivePayment: boolean; // `true` if there's a payment for any of the given plans, `false` otherwise
+  oneTimePurchases: OneTimePurchase[]; // array of one time purchases that have status `ACTIVE`
+  appSubscriptions: AppSubscription[]; // array of current subscriptions
+}
+```
+
+`OneTimePurchase` has the following properties:
+
+```ts
+{
+  id: string; // unique string identifier for this purchase
+  name: string; // name of the plan
+  test: boolean; // `true` if the plan a test plan, `false` otherwise
+  status: string; // status = `ACTIVE`
+}
+```
+
+`AppSubscription` has the following properties:
+
+```ts
+{
+  id: string; // unique string identifier for this purchase
+  name: string; // name of the plan
+  test: boolean; // `true` if the plan a test plan, `false` otherwise
+}
+```
 
 [Back to shopify.billing](./README.md)

--- a/docs/reference/billing/request.md
+++ b/docs/reference/billing/request.md
@@ -148,7 +148,7 @@ The URL to confirm the charge with the merchant.
 >
 > The app **must** redirect the merchant to this URL so that they can confirm the charge before Shopify applies it.
 >
-> The merchant will be sent back to your app's main page after the process is complete.
+> After the process is complete, the merchant will be sent back to the page referenced by the `returnUrl` parameter, if set. Otherwise, the merchant will be sent to your app's main page.
 
 ### if `returnObject` parameter is `true`
 
@@ -189,6 +189,6 @@ The URL to confirm the charge with the merchant.
 >
 > The app **must** redirect the merchant to this URL so that they can confirm the charge before Shopify applies it.
 >
-> The merchant will be sent back to your app's main page after the process is complete.
+> After the process is complete, the merchant will be sent back to the page referenced by the `returnUrl` parameter, if set. Otherwise, the merchant will be sent to your app's main page.
 
 [Back to shopify.billing](./README.md)

--- a/docs/reference/billing/request.md
+++ b/docs/reference/billing/request.md
@@ -2,7 +2,7 @@
 
 Creates a new charge for the merchant, for the given plan.
 
-## Examples
+## Examples (not using return objects)
 
 ### Single-plan setup - charge after OAuth completes
 
@@ -50,6 +50,58 @@ app.post('/api/select-plan', async (req, res) => {
 });
 ```
 
+## Examples (using return objects)
+
+As of version `7.3.0`, `request` can also receive an optional `returnObject` parameter that adjusts what is returned by the method.
+
+### Single-plan setup - charge after OAuth completes
+
+```ts
+app.get('/auth/callback', async () => {
+  const callback = await shopify.auth.callback({
+    rawRequest: req,
+    rawResponse: res,
+  });
+
+  // Check if we require payment, using shopify.billing.check()
+
+  const billingResponse = await shopify.billing.request({
+    session: callback.session,
+    plan: 'My billing plan',
+    isTest: true,
+    returnObject: true,
+  });
+
+  res.redirect(billingResponse.confirmationUrl);
+});
+```
+
+### Multi-plan setup - charge based on user selection
+
+```ts
+app.post('/api/select-plan', async (req, res) => {
+  const sessionId = shopify.session.getCurrentId({
+    isOnline: true,
+    rawRequest: req,
+    rawResponse: res,
+  });
+
+  // use sessionId to retrieve session from app's session storage
+  // In this example, getSessionFromStorage() must be provided by app
+  const session = await getSessionFromStorage(sessionId);
+
+  const billingResponse = await shopify.billing.request({
+    session,
+    // Receive the selected plan from the frontend
+    plan: req.body.selectedPlan,
+    isTest: true,
+    returnObject: true,
+  });
+
+  res.redirect(billingResponse.confirmationUrl);
+});
+```
+
 ## Parameters
 
 Receives an object containing:
@@ -78,13 +130,65 @@ If `true`, Shopify will not actually charge for this purchase.
 
 Which URL to redirect the merchant to after the charge is confirmed.
 
+### returnObject
+
+`boolean` | Defaults to `false`
+
+Whether to return the `confirmationUrl` as a `string`, or to return a more detailed object (see below).
+
 ## Return
 
-`string`
+### if `returnObject` parameter is `false` (default)
 
-The URL to confirm the charge with the merchant - we don't redirect right away to make it possible for apps to run their own code after it creates the payment request.
+`Promise<string>`
 
-The app **must** redirect the merchant to this URL so that they can confirm the charge before Shopify applies it.
-The merchant will be sent back to your app's main page after the process is complete.
+The URL to confirm the charge with the merchant.
+
+> **Note** We don't redirect right away to make it possible for apps to run their own code after it creates the payment request.
+>
+> The app **must** redirect the merchant to this URL so that they can confirm the charge before Shopify applies it.
+>
+> The merchant will be sent back to your app's main page after the process is complete.
+
+### if `returnObject` parameter is `true`
+
+`Promise<BillingRequestResponseObject>`
+
+`BillingRequestResponseObject` has the following properties:
+
+```ts
+{
+  confirmationUrl: string; // The URL to confirm the charge with the merchant, see note below
+  oneTimePurchase?: OneTimePurchase; // will be populated if a one time purchase is requested
+  appSubscription?: AppSubscription; // will be populated if a subscription is requested
+}
+```
+
+`OneTimePurchase` has the following properties:
+
+```ts
+{
+  id: string; // unique string identifier for this purchase
+  name: string; // name of the plan
+  test: boolean; // `true` if the plan a test plan, `false` otherwise
+  status: string; // status = `ACTIVE`
+}
+```
+
+`AppSubscription` has the following properties:
+
+```ts
+{
+  id: string; // unique string identifier for this purchase
+  name: string; // name of the plan
+  test: boolean; // `true` if the plan a test plan, `false` otherwise
+}
+```
+
+> **Note** We don't redirect right away to make it possible for apps to run their own code after it creates the payment request.
+>
+> The app **must** redirect the merchant to this URL so that they can confirm the charge before Shopify applies it.
+>
+> The merchant will be sent back to your app's main page after the process is complete.
 
 [Back to shopify.billing](./README.md)

--- a/lib/billing/__tests__/cancel.test.ts
+++ b/lib/billing/__tests__/cancel.test.ts
@@ -107,7 +107,7 @@ describe('shopify.billing.cancel', () => {
     ).rejects.toThrowError(BillingError);
   });
 
-  test('throws a BillingError when an error occurs', async () => {
+  test('throws a BillingError when a user error occurs', async () => {
     queueMockResponses([Responses.CANCEL_RESPONSE_WITH_USER_ERRORS]);
 
     const {
@@ -126,7 +126,7 @@ describe('shopify.billing.cancel', () => {
     ).rejects.toThrowError(BillingError);
   });
 
-  test('throws a BillingError when a user error occurs', async () => {
+  test('throws a BillingError when an error occurs', async () => {
     queueMockResponses([Responses.CANCEL_RESPONSE_WITH_ERRORS]);
 
     const {

--- a/lib/billing/__tests__/cancel.test.ts
+++ b/lib/billing/__tests__/cancel.test.ts
@@ -106,4 +106,42 @@ describe('shopify.billing.cancel', () => {
       }),
     ).rejects.toThrowError(BillingError);
   });
+
+  test('throws a BillingError when an error occurs', async () => {
+    queueMockResponses([Responses.CANCEL_RESPONSE_WITH_USER_ERRORS]);
+
+    const {
+      data: {
+        currentAppInstallation: {activeSubscriptions},
+      },
+    } = Responses.EXISTING_SUBSCRIPTION_OBJECT;
+
+    const subscriptionId = activeSubscriptions[0].id;
+
+    expect(() =>
+      shopify.billing.cancel({
+        session,
+        subscriptionId,
+      }),
+    ).rejects.toThrowError(BillingError);
+  });
+
+  test('throws a BillingError when a user error occurs', async () => {
+    queueMockResponses([Responses.CANCEL_RESPONSE_WITH_ERRORS]);
+
+    const {
+      data: {
+        currentAppInstallation: {activeSubscriptions},
+      },
+    } = Responses.EXISTING_SUBSCRIPTION_OBJECT;
+
+    const subscriptionId = activeSubscriptions[0].id;
+
+    expect(() =>
+      shopify.billing.cancel({
+        session,
+        subscriptionId,
+      }),
+    ).rejects.toThrowError(BillingError);
+  });
 });

--- a/lib/billing/__tests__/responses.ts
+++ b/lib/billing/__tests__/responses.ts
@@ -1,6 +1,7 @@
 export const PLAN_1 = 'Shopify app plan 1';
 export const PLAN_2 = 'Shopify app plan 2';
-export const ALL_PLANS = [PLAN_1, PLAN_2];
+export const PLAN_3 = 'Shopify app plan 3';
+export const ALL_PLANS = [PLAN_1, PLAN_2, PLAN_3];
 
 export const CONFIRMATION_URL = 'totally-real-url';
 
@@ -102,6 +103,57 @@ export const EXISTING_SUBSCRIPTION_OBJECT = {
   },
 };
 
+export const EXISTING_ONE_TIME_PAYMENTS_WITH_PAGINATION_AND_SUBSCRIPTION = [
+  JSON.stringify({
+    data: {
+      currentAppInstallation: {
+        oneTimePurchases: {
+          edges: [
+            {
+              node: {
+                name: PLAN_1,
+                id: 'gid://010203',
+                test: true,
+                status: 'ACTIVE',
+              },
+            },
+            {
+              node: {
+                name: 'some_other_expired_name',
+                id: 'gid://040506',
+                test: true,
+                status: 'EXPIRED',
+              },
+            },
+          ],
+          pageInfo: {hasNextPage: true, endCursor: 'end_cursor'},
+        },
+        activeSubscriptions: [{id: 'gid://070809', name: PLAN_2, test: true}],
+      },
+    },
+  }),
+  JSON.stringify({
+    data: {
+      currentAppInstallation: {
+        oneTimePurchases: {
+          edges: [
+            {
+              node: {
+                name: PLAN_3,
+                id: 'gid://101112',
+                test: true,
+                status: 'ACTIVE',
+              },
+            },
+          ],
+          pageInfo: {hasNextPage: false, endCursor: null},
+        },
+        activeSubscriptions: [],
+      },
+    },
+  }),
+];
+
 export const EXISTING_SUBSCRIPTION = JSON.stringify(
   EXISTING_SUBSCRIPTION_OBJECT,
 );
@@ -109,6 +161,11 @@ export const EXISTING_SUBSCRIPTION = JSON.stringify(
 export const PURCHASE_ONE_TIME_RESPONSE = JSON.stringify({
   data: {
     appPurchaseOneTimeCreate: {
+      oneTimePurchase: {
+        id: 'gid://123',
+        name: PLAN_1,
+        test: true,
+      },
       confirmationUrl: CONFIRMATION_URL,
       userErrors: [],
     },
@@ -118,6 +175,11 @@ export const PURCHASE_ONE_TIME_RESPONSE = JSON.stringify({
 export const PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({
   data: {
     appSubscriptionCreate: {
+      appSubscription: {
+        id: 'gid://123',
+        name: PLAN_1,
+        test: true,
+      },
       confirmationUrl: CONFIRMATION_URL,
       userErrors: [],
     },
@@ -127,6 +189,11 @@ export const PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({
 export const PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
   data: {
     appPurchaseOneTimeCreate: {
+      oneTimePurchase: {
+        id: 'gid://123',
+        name: PLAN_1,
+        test: true,
+      },
       confirmationUrl: CONFIRMATION_URL,
       userErrors: ['Oops, something went wrong'],
     },
@@ -136,6 +203,11 @@ export const PURCHASE_ONE_TIME_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
 export const PURCHASE_SUBSCRIPTION_RESPONSE_WITH_USER_ERRORS = JSON.stringify({
   data: {
     appSubscriptionCreate: {
+      appSubscription: {
+        id: 'gid://123',
+        name: PLAN_1,
+        test: true,
+      },
       confirmationUrl: CONFIRMATION_URL,
       userErrors: ['Oops, something went wrong'],
     },

--- a/lib/billing/check.ts
+++ b/lib/billing/check.ts
@@ -6,15 +6,20 @@ import {
 import {BillingError} from '../error';
 
 import {
+  AppSubscription,
   BillingCheckParams,
+  BillingCheckResponse,
+  BillingCheckResponseObject,
   CurrentAppInstallation,
   CurrentAppInstallations,
+  OneTimePurchase,
 } from './types';
 
 interface CheckInternalParams {
   plans: string[];
   client: GraphqlClient;
   isTest: boolean;
+  returnObject: boolean;
 }
 
 interface CheckInstallationParams {
@@ -23,12 +28,28 @@ interface CheckInstallationParams {
   installation: CurrentAppInstallation;
 }
 
+type CheckInternalResponse<Params extends CheckInternalParams> =
+  Params['returnObject'] extends true ? BillingCheckResponseObject : boolean;
+
+interface SubscriptionMeetsCriteriaParams {
+  plans: string[];
+  isTest: boolean;
+  subscription: AppSubscription;
+}
+
+interface PurchaseMeetsCriteriaParams {
+  plans: string[];
+  isTest: boolean;
+  purchase: OneTimePurchase;
+}
+
 export function check(config: ConfigInterface) {
-  return async function ({
+  return async function check<Params extends BillingCheckParams>({
     session,
     plans,
     isTest = true,
-  }: BillingCheckParams): Promise<boolean> {
+    returnObject = false,
+  }: Params): Promise<BillingCheckResponse<Params>> {
     if (!config.billing) {
       throw new BillingError({
         message: 'Attempted to look for purchases without billing configs',
@@ -40,19 +61,29 @@ export function check(config: ConfigInterface) {
     const client = new GraphqlClient({session});
 
     const plansArray = Array.isArray(plans) ? plans : [plans];
-    return hasActivePayment({
+    return assessPayments({
       plans: plansArray,
       client,
       isTest,
-    });
+      returnObject,
+    }) as Promise<BillingCheckResponse<Params>>;
   };
 }
 
-async function hasActivePayment({
+async function assessPayments<Params extends CheckInternalParams>({
   plans,
   client,
   isTest,
-}: CheckInternalParams): Promise<boolean> {
+  returnObject,
+}: Params): Promise<CheckInternalResponse<Params>> {
+  const returnValue: BillingCheckResponseObject | boolean = returnObject
+    ? {
+        hasActivePayment: false,
+        oneTimePurchases: [],
+        appSubscriptions: [],
+      }
+    : false;
+
   let installation: CurrentAppInstallation;
   let endCursor: string | null = null;
   do {
@@ -64,17 +95,53 @@ async function hasActivePayment({
     });
 
     installation = currentInstallations.body.data.currentAppInstallation;
-    if (
-      hasSubscription({plans, isTest, installation}) ||
-      hasOneTimePayment({plans, isTest, installation})
-    ) {
-      return true;
+    if (returnObject) {
+      installation.activeSubscriptions.map((subscription) => {
+        if (subscriptionMeetsCriteria({plans, isTest, subscription})) {
+          (returnValue as BillingCheckResponseObject).hasActivePayment = true;
+          (returnValue as BillingCheckResponseObject).appSubscriptions.push(
+            subscription,
+          );
+        }
+      });
+      installation.oneTimePurchases.edges.map((purchase) => {
+        if (purchaseMeetsCriteria({plans, isTest, purchase: purchase.node})) {
+          (returnValue as BillingCheckResponseObject).hasActivePayment = true;
+          (returnValue as BillingCheckResponseObject).oneTimePurchases.push(
+            purchase.node,
+          );
+        }
+      });
+    } else {
+      const params = {plans, isTest, installation};
+      if (hasSubscription(params) || hasOneTimePayment(params)) {
+        return true as CheckInternalResponse<Params>;
+      }
     }
-
     endCursor = installation.oneTimePurchases.pageInfo.endCursor;
   } while (installation?.oneTimePurchases.pageInfo.hasNextPage);
 
-  return false;
+  return returnValue as CheckInternalResponse<Params>;
+}
+
+function subscriptionMeetsCriteria({
+  plans,
+  isTest,
+  subscription,
+}: SubscriptionMeetsCriteriaParams): boolean {
+  return plans.includes(subscription.name) && (isTest || !subscription.test);
+}
+
+function purchaseMeetsCriteria({
+  plans,
+  isTest,
+  purchase,
+}: PurchaseMeetsCriteriaParams): boolean {
+  return (
+    plans.includes(purchase.name) &&
+    (isTest || !purchase.test) &&
+    purchase.status === 'ACTIVE'
+  );
 }
 
 function hasSubscription({
@@ -82,9 +149,8 @@ function hasSubscription({
   isTest,
   installation,
 }: CheckInstallationParams): boolean {
-  return installation.activeSubscriptions.some(
-    (subscription) =>
-      plans.includes(subscription.name) && (isTest || !subscription.test),
+  return installation.activeSubscriptions.some((subscription) =>
+    subscriptionMeetsCriteria({plans, isTest, subscription}),
   );
 }
 
@@ -93,11 +159,8 @@ function hasOneTimePayment({
   isTest,
   installation,
 }: CheckInstallationParams): boolean {
-  return installation.oneTimePurchases.edges.some(
-    (purchase) =>
-      plans.includes(purchase.node.name) &&
-      (isTest || !purchase.node.test) &&
-      purchase.node.status === 'ACTIVE',
+  return installation.oneTimePurchases.edges.some((purchase) =>
+    purchaseMeetsCriteria({plans, isTest, purchase: purchase.node}),
   );
 }
 
@@ -105,6 +168,7 @@ const HAS_PAYMENTS_QUERY = `
   query appSubscription($endCursor: String) {
     currentAppInstallation {
       activeSubscriptions {
+        id
         name
         test
       }
@@ -112,6 +176,7 @@ const HAS_PAYMENTS_QUERY = `
       oneTimePurchases(first: 250, sortKey: CREATED_AT, after: $endCursor) {
         edges {
           node {
+            id
             name
             test
             status

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -56,14 +56,34 @@ export interface BillingCheckParams {
   session: Session;
   plans: string[] | string;
   isTest?: boolean;
+  returnObject?: boolean;
 }
+
+export interface BillingCheckResponseObject {
+  hasActivePayment: boolean;
+  oneTimePurchases: OneTimePurchase[];
+  appSubscriptions: AppSubscription[];
+}
+
+export type BillingCheckResponse<Params extends BillingCheckParams> =
+  Params['returnObject'] extends true ? BillingCheckResponseObject : boolean;
 
 export interface BillingRequestParams {
   session: Session;
   plan: string;
   isTest?: boolean;
   returnUrl?: string;
+  returnObject?: boolean;
 }
+
+export interface BillingRequestResponseObject {
+  confirmationUrl: string;
+  oneTimePurchase?: OneTimePurchase;
+  appSubscription?: AppSubscription;
+}
+
+export type BillingRequestResponse<Params extends BillingRequestParams> =
+  Params['returnObject'] extends true ? BillingRequestResponseObject : string;
 
 export interface BillingCancelParams {
   session: Session;
@@ -86,7 +106,8 @@ export interface ActiveSubscriptions {
   activeSubscriptions: AppSubscription[];
 }
 
-interface OneTimePurchase {
+export interface OneTimePurchase {
+  id: string;
   name: string;
   test: boolean;
   status: string;
@@ -120,17 +141,29 @@ export interface RequestResponse {
 
 export interface RecurringPaymentResponse {
   data: {
-    appSubscriptionCreate: RequestResponse;
+    appSubscriptionCreate: {
+      userErrors: string[];
+      confirmationUrl: string;
+      appSubscription: AppSubscription;
+    };
   };
   errors?: string[];
 }
 
 export interface SinglePaymentResponse {
   data: {
-    appPurchaseOneTimeCreate: RequestResponse;
+    appPurchaseOneTimeCreate: {
+      userErrors: string[];
+      confirmationUrl: string;
+      oneTimePurchase: OneTimePurchase;
+    };
   };
   errors?: string[];
 }
+
+export type RequestResponseData =
+  | RecurringPaymentResponse['data']['appSubscriptionCreate']
+  | SinglePaymentResponse['data']['appPurchaseOneTimeCreate'];
 
 export interface SubscriptionResponse {
   data: {


### PR DESCRIPTION
### WHY are these changes introduced?

Add an optional parameter to `check` and `request` to return an object with payment/subscription details, including the `id`, that can be stored and used in a subsequent `cancel` if needed.

Parameter `returnObject` is optional and defaults to `false` (current published behaviour).

### WHAT is this pull request doing?

See above ☝🏻 

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
