### PR TITLE
Add shop to billing return URL

### DIFF
--- a/.changeset/smart-plums-decide.md
+++ b/.changeset/smart-plums-decide.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Add shop search param to default billing return URL for non-embedded apps

--- a/lib/billing/__tests__/request.test.ts
+++ b/lib/billing/__tests__/request.test.ts
@@ -243,7 +243,7 @@ describe('shopify.billing.request', () => {
                   query: expect.stringContaining(config.mutationName),
                   variables: expect.objectContaining({
                     test: isTest,
-                    returnUrl: 'https://test_host_name',
+                    returnUrl: `https://test_host_name?shop=${DOMAIN}`,
                   }),
                 },
               }).toMatchMadeHttpRequest();

--- a/lib/billing/request.ts
+++ b/lib/billing/request.ts
@@ -61,7 +61,7 @@ export function request(config: ConfigInterface) {
       hashString(`admin.shopify.com/store/${cleanShopName}`, HashFormat.Base64),
     );
 
-    const appUrl = `${config.hostScheme}://${config.hostName}`;
+    const appUrl = `${config.hostScheme}://${config.hostName}?shop=${session.shop}`;
 
     // if provided a return URL, use it, otherwise use the embedded app URL or hosted app URL
     const returnUrl =


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, when requesting billing on a non-embedded app, we're returning to the app's root by default, which is sane. However, we don't have a shop search param, which means some apps might not know which shop is loading the app.

### WHAT is this pull request doing?

Simply adding the shop as a search param in the default `/` return URL.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
