### PR TITLE
Deprecate privateMetafieldNamespaces field

### DIFF
--- a/.changeset/itchy-boats-run.md
+++ b/.changeset/itchy-boats-run.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Deprecated privateMetafieldNamespaces field in HTTP webhook configurations

--- a/docs/reference/webhooks/addHandlers.md
+++ b/docs/reference/webhooks/addHandlers.md
@@ -82,7 +82,7 @@ The `async` callback to call when a shop triggers a `topic` event.
 
 #### privateMetafieldNamespaces
 
-`string[]` | Defaults to `[]`
+`string[]` | Defaults to `[]` | :warning: deprecated, will be removed in v8.0.0
 
 Namespaces to be included in the callback, defaulting to all of them.
 

--- a/lib/webhooks/__tests__/register.test.ts
+++ b/lib/webhooks/__tests__/register.test.ts
@@ -110,7 +110,7 @@ describe('shopify.webhooks.register', () => {
     const topic = 'PRODUCTS_CREATE';
     const handler: WebhookHandler = {
       ...HTTP_HANDLER,
-      privateMetafieldNamespaces: ['new-private-namespace'],
+      metafieldNamespaces: ['new-namespace'],
     };
     const responses = [mockResponses.successUpdateResponse];
 
@@ -126,7 +126,7 @@ describe('shopify.webhooks.register', () => {
       `id: "${mockResponses.TEST_WEBHOOK_ID}"`,
       {
         callbackUrl: `"https://test_host_name/webhooks"`,
-        privateMetafieldNamespaces: '["new-private-namespace"]',
+        metafieldNamespaces: '["new-namespace"]',
       },
     );
     assertRegisterResponse({registerReturn, topic, responses});

--- a/lib/webhooks/registry.ts
+++ b/lib/webhooks/registry.ts
@@ -85,9 +85,18 @@ function mergeOrAddHandler(
   topic: string,
   handler: WebhookHandler,
 ) {
+  const log = logger(config);
+
   handler.includeFields?.sort();
   handler.metafieldNamespaces?.sort();
   if (handler.deliveryMethod === DeliveryMethod.Http) {
+    if (handler.privateMetafieldNamespaces) {
+      log.deprecated(
+        '8.0.0',
+        'The privateMetafieldNamespaces handler option is deprecated, and will be removed in v8.0.0. See https://shopify.dev/docs/apps/custom-data/metafields/migrate-private-metafields',
+      );
+    }
+
     handler.privateMetafieldNamespaces?.sort();
   }
 
@@ -111,7 +120,7 @@ function mergeOrAddHandler(
     }
 
     if (handler.deliveryMethod === DeliveryMethod.Http) {
-      logger(config).info(
+      log.info(
         `Detected multiple handlers for '${topic}', webhooks.process will call them sequentially`,
       );
       break;

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -23,6 +23,7 @@ interface BaseWebhookHandler {
 
 export interface HttpWebhookHandler extends BaseWebhookHandler {
   deliveryMethod: DeliveryMethod.Http;
+  // Deprecated, should be removed in next major release
   privateMetafieldNamespaces?: string[];
   callbackUrl: string;
 }
@@ -97,6 +98,7 @@ export interface WebhookCheckResponseNode<
     topic: string;
     includeFields: string[];
     metafieldNamespaces: string[];
+    // Deprecated, should be removed in next major release
     privateMetafieldNamespaces: string[];
   } & T;
 }


### PR DESCRIPTION
### WHY are these changes introduced?

The GraphQL API has deprecated the `privateMetafieldNamespaces` in webhook subscriptions, which means we should stop sending that field. It won't be removed imminently, but we should fully drop support when doing a major release.

### WHAT is this pull request doing?

Marking the field as deprecated, so we can fully remove it and eliminate the log message in the next major release.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
