### PR TITLE
Return webhook registration operation

### DIFF
--- a/.changeset/sour-crabs-brush.md
+++ b/.changeset/sour-crabs-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Return the performed operation for each handler when registering webhooks

--- a/docs/reference/webhooks/register.md
+++ b/docs/reference/webhooks/register.md
@@ -53,11 +53,23 @@ Returns an object containing a list of results, indexed by topic. Each entry in 
 
 Whether the registration was successful.
 
+### deliveryMethod
+
+`string`
+
+The configured delivery method for the registered webhook.
+
 ### result
 
 `array`
 
 The body from the Shopify request to register the webhook.
+
+### operation
+
+`WebhookOperation`
+
+Which operation was performed to obtain this result.
 
 > **Note**: This object will only contain results for a handler if any of its information was updated with Shopify.
 

--- a/lib/webhooks/__tests__/register.test.ts
+++ b/lib/webhooks/__tests__/register.test.ts
@@ -368,10 +368,10 @@ describe('shopify.webhooks.register', () => {
   });
 
   it('returns which operation was done for each handler', async () => {
+    // We have a pre-existing webhook for PRODUCTS_CREATE, so we expect it to be deleted, whereas we expect a new one to
+    // be created for PRODUCTS_DELETE
     shopify.webhooks.addHandlers({
       PRODUCTS_UPDATE: {...HTTP_HANDLER, includeFields: ['id', 'title']},
-    });
-    shopify.webhooks.addHandlers({
       PRODUCTS_DELETE: HTTP_HANDLER,
     });
 

--- a/lib/webhooks/__tests__/register.test.ts
+++ b/lib/webhooks/__tests__/register.test.ts
@@ -1,9 +1,18 @@
 import {Method, Header} from '@shopify/network';
 
-import {RegisterParams, RegisterReturn, WebhookHandler} from '../types';
+import {
+  RegisterParams,
+  RegisterReturn,
+  WebhookHandler,
+  WebhookOperation,
+} from '../types';
 import {gdprTopics, ShopifyHeader} from '../../types';
 import {DataType} from '../../clients/types';
-import {queueMockResponse, shopify} from '../../__tests__/test-helper';
+import {
+  queueMockResponse,
+  queueMockResponses,
+  shopify,
+} from '../../__tests__/test-helper';
 import {mockTestRequests} from '../../../adapters/mock/mock_test_requests';
 import {queryTemplate} from '../query-template';
 import {TEMPLATE_GET_HANDLERS, TEMPLATE_MUTATION} from '../register';
@@ -356,6 +365,34 @@ describe('shopify.webhooks.register', () => {
       {arn: '"arn:test"'},
     );
     assertRegisterResponse({registerReturn, topic, responses});
+  });
+
+  it('returns which operation was done for each handler', async () => {
+    shopify.webhooks.addHandlers({
+      PRODUCTS_UPDATE: {...HTTP_HANDLER, includeFields: ['id', 'title']},
+    });
+    shopify.webhooks.addHandlers({
+      PRODUCTS_DELETE: HTTP_HANDLER,
+    });
+
+    queueMockResponses(
+      [JSON.stringify(mockResponses.webhookCheckMultiHandlerResponse)],
+      [JSON.stringify(mockResponses.successResponse)],
+      [JSON.stringify(mockResponses.successUpdateResponse)],
+      [JSON.stringify(mockResponses.successDeleteResponse)],
+    );
+
+    const registerReturn = await shopify.webhooks.register({session});
+
+    expect(registerReturn.PRODUCTS_CREATE[0].operation).toEqual(
+      WebhookOperation.Delete,
+    );
+    expect(registerReturn.PRODUCTS_DELETE[0].operation).toEqual(
+      WebhookOperation.Create,
+    );
+    expect(registerReturn.PRODUCTS_UPDATE[0].operation).toEqual(
+      WebhookOperation.Update,
+    );
   });
 });
 

--- a/lib/webhooks/register.ts
+++ b/lib/webhooks/register.ts
@@ -367,6 +367,7 @@ async function runMutation({
       deliveryMethod: handler.deliveryMethod,
       success: isSuccess(result.body, handler, operation),
       result: result.body,
+      operation,
     };
   } catch (error) {
     if (error instanceof InvalidDeliveryMethodError) {
@@ -374,6 +375,7 @@ async function runMutation({
         deliveryMethod: handler.deliveryMethod,
         success: false,
         result: {message: error.message},
+        operation,
       };
     } else {
       throw error;

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -55,6 +55,9 @@ export interface WebhookRegistry<
   [topic: string]: Handler[];
 }
 
+// eslint-disable-next-line no-warning-comments
+// TODO Rethink the wording for this enum - the operations we're doing are actually "subscribing" and "unsubscribing"
+// Consider changing the values when releasing v8.0.0 when it can be safely deprecated
 export enum WebhookOperation {
   Create = 'create',
   Update = 'update',

--- a/lib/webhooks/types.ts
+++ b/lib/webhooks/types.ts
@@ -69,6 +69,7 @@ export interface RegisterResult {
   success: boolean;
   deliveryMethod: DeliveryMethod;
   result: unknown;
+  operation: WebhookOperation;
 }
 
 export interface RegisterReturn {


### PR DESCRIPTION
### WHY are these changes introduced?

When registering webhooks, sometimes it can be hard to tell from the logs exactly what operation was done for each handler in the results.

### WHAT is this pull request doing?

Adding the operation to the returned object to make it more informative.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
