### PR TITLE
Stop sending deprecated field in webhook queries

### DIFF
--- a/.changeset/afraid-games-march.md
+++ b/.changeset/afraid-games-march.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Stop sending the privateMetafieldNamespaces field in webhook queries to avoid the API duplication warning, and added a new shopify.utils.versionPriorTo method to help with cases like this one where apps will need to stop doing something that was deprecated.

--- a/docs/reference/utils/README.md
+++ b/docs/reference/utils/README.md
@@ -2,11 +2,12 @@
 
 This object contains generic helper functions that might simplify app code.
 
-| Property                                    | Description                                                                          |
-| ------------------------------------------- | ------------------------------------------------------------------------------------ |
-| [sanitizeShop](./sanitizeShop.md)           | Validates and sanitizes Shopify shop domains to make user input safer.               |
-| [sanitizeHost](./sanitizeHost.md)           | Validates and sanitizes the `host` argument from Shopify for embedded apps.          |
-| [validateHmac](./validateHmac.md)           | Validates the HMAC signature in requests from Shopify.                               |
-| [versionCompatible](./versionCompatible.md) | Checks whether the given API version is compatible with the current library version. |
+| Property                                    | Description                                                                                 |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| [sanitizeShop](./sanitizeShop.md)           | Validates and sanitizes Shopify shop domains to make user input safer.                      |
+| [sanitizeHost](./sanitizeHost.md)           | Validates and sanitizes the `host` argument from Shopify for embedded apps.                 |
+| [validateHmac](./validateHmac.md)           | Validates the HMAC signature in requests from Shopify.                                      |
+| [versionCompatible](./versionCompatible.md) | Checks whether the current library version is equal to or newer than the given API version. |
+| [versionPriorTo](./versionPriorTo.md)       | Checks whether the current library version is older than the given API version.             |
 
 [Back to shopifyApi](../shopifyApi.md)

--- a/docs/reference/utils/versionPriorTo.md
+++ b/docs/reference/utils/versionPriorTo.md
@@ -1,0 +1,36 @@
+# shopify.utils.versionPriorTo
+
+This method determines if the given version is older than the configured `apiVersion` for the `shopifyApi` object.
+Its main use is when you want to tweak behaviour depending on your current API version, though apps won't typically need this kind of check.
+
+## Example
+
+```ts
+const shopify = shopifyApi({
+  apiVersion: ApiVersion.July23,
+});
+
+if (shopify.utils.versionPriorTo(ApiVersion.July23)) {
+  // false in this example, as both versions are July23
+}
+if (shopify.utils.versionPriorTo(ApiVersion.October23)) {
+  // true in this example, as ApiVersion.October23 is newer than ApiVersion.July23, i.e. the configured version is older
+  // than the reference one
+}
+```
+
+## Parameters
+
+### apiVersion
+
+`ApiVersion` | :exclamation: required
+
+The API version to check against.
+
+## Return
+
+`boolean`
+
+Whether the reference version is older than the configured version.
+
+[Back to shopify.utils](./README.md)

--- a/lib/logger/__tests__/logger.test.ts
+++ b/lib/logger/__tests__/logger.test.ts
@@ -221,8 +221,9 @@ describe('shopify.logger', () => {
   it('can use a custom async logger', async () => {
     const testLogFilePath = path.join(__dirname, 'test.log');
 
+    let promise: Promise<any> = Promise.resolve();
     const log = (severity: LogSeverity, message: string) => {
-      fs.promises
+      promise = fs.promises
         .writeFile(testLogFilePath, `${severity}: ${message}`)
         .catch((error) => {
           console.error(error);
@@ -236,7 +237,9 @@ describe('shopify.logger', () => {
 
     shopify.logger.log(LogSeverity.Debug, 'debug message');
 
-    fs.appendFileSync(testLogFilePath, '');
+    // Wait for the write operation to finish
+    await promise;
+
     const logContent = await fs.promises.readFile(testLogFilePath, 'utf8');
 
     expect(logContent).toEqual(

--- a/lib/utils/__tests__/version-compatible.test.ts
+++ b/lib/utils/__tests__/version-compatible.test.ts
@@ -1,0 +1,70 @@
+import {shopify} from '../../__tests__/test-helper';
+import {ApiVersion} from '../../types';
+
+describe('versionCompatible', () => {
+  it('returns true if version is Unstable', () => {
+    shopify.config.apiVersion = ApiVersion.Unstable;
+
+    const result = shopify.utils.versionCompatible(ApiVersion.April23);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true if version is equal to the configured one', () => {
+    shopify.config.apiVersion = ApiVersion.April23;
+
+    const result = shopify.utils.versionCompatible(ApiVersion.April23);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns true if version is newer than the configured one', () => {
+    shopify.config.apiVersion = ApiVersion.April23;
+
+    const result = shopify.utils.versionCompatible(ApiVersion.January23);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false if version is older than the configured one', () => {
+    shopify.config.apiVersion = ApiVersion.January23;
+
+    const result = shopify.utils.versionCompatible(ApiVersion.April23);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('versionPriorTo', () => {
+  it('returns false if version is Unstable (unstable is newer than any version)', () => {
+    shopify.config.apiVersion = ApiVersion.Unstable;
+
+    const result = shopify.utils.versionPriorTo(ApiVersion.April23);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false if version is equal to the configured one', () => {
+    shopify.config.apiVersion = ApiVersion.April23;
+
+    const result = shopify.utils.versionPriorTo(ApiVersion.April23);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false if version is newer than the configured one', () => {
+    shopify.config.apiVersion = ApiVersion.April23;
+
+    const result = shopify.utils.versionPriorTo(ApiVersion.January23);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns true if version is older than the configured one', () => {
+    shopify.config.apiVersion = ApiVersion.January23;
+
+    const result = shopify.utils.versionPriorTo(ApiVersion.April23);
+
+    expect(result).toBe(true);
+  });
+});

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -2,7 +2,7 @@ import {ConfigInterface} from '../base-types';
 
 import {sanitizeShop, sanitizeHost} from './shop-validator';
 import {validateHmac} from './hmac-validator';
-import {versionCompatible} from './version-compatible';
+import {versionCompatible, versionPriorTo} from './version-compatible';
 
 export function shopifyUtils(config: ConfigInterface) {
   return {
@@ -10,6 +10,7 @@ export function shopifyUtils(config: ConfigInterface) {
     sanitizeHost: sanitizeHost(config),
     validateHmac: validateHmac(config),
     versionCompatible: versionCompatible(config),
+    versionPriorTo: versionPriorTo(config),
   };
 }
 

--- a/lib/utils/version-compatible.ts
+++ b/lib/utils/version-compatible.ts
@@ -17,3 +17,12 @@ export function versionCompatible(config: ConfigInterface) {
     return current >= reference;
   };
 }
+
+export function versionPriorTo(config: ConfigInterface) {
+  return (
+    referenceVersion: ApiVersion,
+    currentVersion: ApiVersion = config.apiVersion,
+  ): boolean => {
+    return !versionCompatible(config)(referenceVersion, currentVersion);
+  };
+}

--- a/lib/webhooks/register.ts
+++ b/lib/webhooks/register.ts
@@ -151,16 +151,26 @@ async function getExistingHandlers(
 }
 
 function buildCheckQuery(config: ConfigInterface, endCursor: string | null) {
-  let query = queryTemplate(TEMPLATE_GET_HANDLERS, {
-    END_CURSOR: JSON.stringify(endCursor),
-  });
+  return removeDeprecatedFields(
+    config,
+    queryTemplate(TEMPLATE_GET_HANDLERS, {
+      END_CURSOR: JSON.stringify(endCursor),
+    }),
+  );
+}
+
+function removeDeprecatedFields(
+  config: ConfigInterface,
+  query: string,
+): string {
+  let processedQuery = query;
 
   // The privateMetafieldNamespaces field was deprecated in the July22 version, so we need to stop sending it
   if (versionCompatible(config)(ApiVersion.July22)) {
-    query = query.replace('privateMetafieldNamespaces', '');
+    processedQuery = processedQuery.replace('privateMetafieldNamespaces', '');
   }
 
-  return query;
+  return processedQuery;
 }
 
 function buildHandlerFromNode(edge: WebhookCheckResponseNode): WebhookHandler {

--- a/lib/webhooks/register.ts
+++ b/lib/webhooks/register.ts
@@ -1,10 +1,11 @@
+import {versionCompatible, versionPriorTo} from '../utils/version-compatible';
 import {
   graphqlClientClass,
   GraphqlClient,
 } from '../clients/graphql/graphql_client';
 import {InvalidDeliveryMethodError, ShopifyError} from '../error';
 import {logger} from '../logger';
-import {gdprTopics} from '../types';
+import {ApiVersion, gdprTopics} from '../types';
 import {ConfigInterface} from '../base-types';
 import {Session} from '../session/session';
 
@@ -126,7 +127,7 @@ async function getExistingHandlers(
   let hasNextPage: boolean;
   let endCursor: string | null = null;
   do {
-    const query = buildCheckQuery(endCursor);
+    const query = buildCheckQuery(config, endCursor);
 
     const response = await client.query<WebhookCheckResponse>({
       data: query,
@@ -149,10 +150,17 @@ async function getExistingHandlers(
   return existingHandlers;
 }
 
-function buildCheckQuery(endCursor: string | null) {
-  return queryTemplate(TEMPLATE_GET_HANDLERS, {
+function buildCheckQuery(config: ConfigInterface, endCursor: string | null) {
+  let query = queryTemplate(TEMPLATE_GET_HANDLERS, {
     END_CURSOR: JSON.stringify(endCursor),
   });
+
+  // The privateMetafieldNamespaces field was deprecated in the July22 version, so we need to stop sending it
+  if (versionCompatible(config)(ApiVersion.July22)) {
+    query = query.replace('privateMetafieldNamespaces', '');
+  }
+
+  return query;
 }
 
 function buildHandlerFromNode(edge: WebhookCheckResponseNode): WebhookHandler {
@@ -433,9 +441,12 @@ function buildMutation(
     if (handler.metafieldNamespaces) {
       params.metafieldNamespaces = JSON.stringify(handler.metafieldNamespaces);
     }
+
     if (
       handler.deliveryMethod === DeliveryMethod.Http &&
-      handler.privateMetafieldNamespaces
+      handler.privateMetafieldNamespaces &&
+      // This field was deprecated in the July22 version
+      versionPriorTo(config)(ApiVersion.July22)
     ) {
       params.privateMetafieldNamespaces = JSON.stringify(
         handler.privateMetafieldNamespaces,


### PR DESCRIPTION
### WHY are these changes introduced?

The `privateMetafieldNamespaces` field was deprecated from the webhooks queries in the GraphQL API, so we need to stop sending it in order to stop triggering the API warning.

### WHAT is this pull request doing?

We'd already deprecated the configuration field itself, but we should also stop sending it in queries since it will just be ignored. Since I needed to check if the app was behind a certain version to do that, I added a new `versionPriorTo` method which is just `versionCompatible` inversed.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
