### PR TITLE
[Setting] Add july api to available versions

### DIFF
--- a/.changeset/cuddly-pandas-hug.md
+++ b/.changeset/cuddly-pandas-hug.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Adding the 2023-07 api version to supported and exported api versions

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,7 +5,7 @@ export enum LogSeverity {
   Debug,
 }
 
-export enum ApiVersion 
+export enum ApiVersion {
   April22 = '2022-04',
   July22 = '2022-07',
   October22 = '2022-10',

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -5,12 +5,13 @@ export enum LogSeverity {
   Debug,
 }
 
-export enum ApiVersion {
+export enum ApiVersion 
   April22 = '2022-04',
   July22 = '2022-07',
   October22 = '2022-10',
   January23 = '2023-01',
   April23 = '2023-04',
+  July23 = '2023-07',
   Unstable = 'unstable',
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Shopifys newest admin api is in version 2023-07 which is not reflected in this liibrary.

### WHAT is this pull request doing?

Adding the new api version string to exported api versions.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
