### PR TITLE
Allow not checking session token aud field

### DIFF
--- a/.changeset/brown-hounds-suffer.md
+++ b/.changeset/brown-hounds-suffer.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Allow not checking a session token payload's `aud` field to support tokens generated outside of the Shopify Admin.

--- a/.github/workflows/markdown_link_checker_config.json
+++ b/.github/workflows/markdown_link_checker_config.json
@@ -1,4 +1,9 @@
 {
   "retryOn429": true,
-  "fallbackRetryDelay": "1s"
+  "fallbackRetryDelay": "1s",
+  "ignorePatterns": [
+    {
+      "pattern": "^https://help.shopify.com"
+    }
+  ]
 }

--- a/docs/reference/session/decodeSessionToken.md
+++ b/docs/reference/session/decodeSessionToken.md
@@ -22,6 +22,19 @@ app.get('/fetch-some-data', async (req, res) => {
 
 The token to parse.
 
+### options
+
+`Object`
+
+An object that allows the following fields:
+
+#### checkAudience
+
+`boolean` | Defaults to `true`
+
+Whether the method should check the `aud` field in the decoded payload.
+This should always be set to `true` if the token is coming from the Shopify Admin.
+
 ## Return
 
 `Promise<JwtPayload>`

--- a/lib/session/__tests__/decode-session-token.test.ts
+++ b/lib/session/__tests__/decode-session-token.test.ts
@@ -65,4 +65,29 @@ describe('JWT session token', () => {
       ShopifyErrors.InvalidJwtError,
     );
   });
+
+  test("doesn't fail on a mismatching API key when not checking the token's audience", async () => {
+    shopify.config.apiKey = 'something_else';
+
+    // The token is signed with a key that is not the current value
+    const token = await signJWT(shopify.config.apiSecretKey, payload);
+
+    const actualPayload = await shopify.session.decodeSessionToken(token, {
+      checkAudience: false,
+    });
+    expect(actualPayload).toStrictEqual(payload);
+  });
+
+  test("doesn't fail on a missing aud field when not checking the token's audience", async () => {
+    const payloadWithoutAud = {...payload};
+    delete (payloadWithoutAud as any).aud;
+
+    // The token is signed with a key that is not the current value
+    const token = await signJWT(shopify.config.apiSecretKey, payload);
+
+    const actualPayload = await shopify.session.decodeSessionToken(token, {
+      checkAudience: false,
+    });
+    expect(actualPayload).toStrictEqual(payload);
+  });
 });

--- a/lib/session/decode-session-token.ts
+++ b/lib/session/decode-session-token.ts
@@ -8,8 +8,15 @@ import {JwtPayload} from './types';
 
 const JWT_PERMITTED_CLOCK_TOLERANCE = 10;
 
+export interface DecodeSessionTokenOptions {
+  checkAudience?: boolean;
+}
+
 export function decodeSessionToken(config: ConfigInterface) {
-  return async (token: string): Promise<JwtPayload> => {
+  return async (
+    token: string,
+    {checkAudience = true}: DecodeSessionTokenOptions = {},
+  ): Promise<JwtPayload> => {
     let payload: JwtPayload;
     try {
       payload = (
@@ -26,7 +33,7 @@ export function decodeSessionToken(config: ConfigInterface) {
 
     // The exp and nbf fields are validated by the JWT library
 
-    if (payload.aud !== config.apiKey) {
+    if (checkAudience && payload.aud !== config.apiKey) {
       throw new ShopifyErrors.InvalidJwtError(
         'Session token had invalid API key',
       );


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, we're always checking that a session token's `aud` field matches the app's configured `apiKey`. While that is true for any token generated in the admin, it is not the case in some other scenarios like checkout extensions, where the token doesn't come from the admin.

### WHAT is this pull request doing?

Making it possible for `shopify.session.decodeSessionToken` to not check the decoded payload's `aud` field, so that we can properly support those cases where it isn't set.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
