### PR TITLE
Add storefront missing headers

### DIFF
--- a/.changeset/beige-kids-build.md
+++ b/.changeset/beige-kids-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Fix storefront header incorrectly setting private token as access token

--- a/lib/clients/graphql/__tests__/storefront_client.test.ts
+++ b/lib/clients/graphql/__tests__/storefront_client.test.ts
@@ -96,7 +96,7 @@ describe('Storefront GraphQL client', () => {
       path: `/api/${shopify.config.apiVersion}/graphql.json`,
       data: QUERY,
       headers: {
-        [ShopifyHeader.StorefrontAccessToken]: 'private_token',
+        [ShopifyHeader.StorefrontPrivateToken]: 'private_token',
       },
     }).toMatchMadeHttpRequest();
   });

--- a/lib/clients/graphql/storefront_client.ts
+++ b/lib/clients/graphql/storefront_client.ts
@@ -41,17 +41,16 @@ export class StorefrontClient extends GraphqlClient {
 
   protected getApiHeaders(): HeaderParams {
     const sdkVariant = LIBRARY_NAME.toLowerCase().split(' ').join('-');
-    const usePrivateToken =
-      this.storefrontClass().config.isCustomStoreApp &&
+    const privateToken =
       this.storefrontClass().config.privateAppStorefrontAccessToken;
-    const tokenHeader = usePrivateToken
-      ? ({
-          [ShopifyHeader.StorefrontPrivateToken]:
-            this.storefrontClass().config.privateAppStorefrontAccessToken,
-        } as HeaderParams)
-      : {[ShopifyHeader.StorefrontAccessToken]: this.storefrontAccessToken};
+    const tokenHeaderParam =
+      privateToken === undefined
+        ? {[ShopifyHeader.StorefrontAccessToken]: this.storefrontAccessToken}
+        : ({
+            [ShopifyHeader.StorefrontPrivateToken]: privateToken,
+          } as HeaderParams);
     return {
-      ...tokenHeader,
+      ...tokenHeaderParam,
       [ShopifyHeader.StorefrontSDKVariant]: sdkVariant,
       [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
     };

--- a/lib/clients/graphql/storefront_client.ts
+++ b/lib/clients/graphql/storefront_client.ts
@@ -41,13 +41,17 @@ export class StorefrontClient extends GraphqlClient {
 
   protected getApiHeaders(): HeaderParams {
     const sdkVariant = LIBRARY_NAME.toLowerCase().split(' ').join('-');
-
+    const usePrivateToken =
+      this.storefrontClass().config.isCustomStoreApp &&
+      this.storefrontClass().config.privateAppStorefrontAccessToken;
+    const tokenHeader = usePrivateToken
+      ? ({
+          [ShopifyHeader.StorefrontPrivateToken]:
+            this.storefrontClass().config.privateAppStorefrontAccessToken,
+        } as HeaderParams)
+      : {[ShopifyHeader.StorefrontAccessToken]: this.storefrontAccessToken};
     return {
-      [ShopifyHeader.StorefrontAccessToken]: this.storefrontClass().config
-        .isCustomStoreApp
-        ? this.storefrontClass().config.privateAppStorefrontAccessToken ||
-          this.storefrontAccessToken
-        : this.storefrontAccessToken,
+      ...tokenHeader,
       [ShopifyHeader.StorefrontSDKVariant]: sdkVariant,
       [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
     };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -27,6 +27,7 @@ export enum ShopifyHeader {
   Topic = 'X-Shopify-Topic',
   WebhookId = 'X-Shopify-Webhook-Id',
   StorefrontAccessToken = 'X-Shopify-Storefront-Access-Token',
+  StorefrontPrivateToken = 'Shopify-Storefront-Private-Token',
   StorefrontSDKVariant = 'X-SDK-Variant',
   StorefrontSDKVersion = 'X-SDK-Version',
 }


### PR DESCRIPTION
Private tokens now use the right token name for header

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?
We are assigning the private storefront token to the wrong token name, `X-Shopify-Storefront-Access-Token`, instead of `Shopify-Storefront-Private-Token` 
### WHAT is this pull request doing?
Using `Shopify-Storefront-Private-Token` if the config has a private token

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
