### PR TITLE
Allow billing request trialDays override

### DIFF
--- a/.changeset/tasty-foxes-work.md
+++ b/.changeset/tasty-foxes-work.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Add new trialDaysOverride parameter to billing.request, so that apps can override the default config value.

--- a/.changeset/tasty-foxes-work.md
+++ b/.changeset/tasty-foxes-work.md
@@ -2,4 +2,4 @@
 '@shopify/shopify-api': minor
 ---
 
-Add new trialDaysOverride parameter to billing.request, so that apps can override the default config value.
+Add new trialDays parameter to billing.request, so that apps can override the default config value.

--- a/docs/reference/billing/request.md
+++ b/docs/reference/billing/request.md
@@ -136,6 +136,12 @@ Which URL to redirect the merchant to after the charge is confirmed.
 
 Whether to return the `confirmationUrl` as a `string`, or to return a more detailed object (see below).
 
+### trialDaysOverride
+
+`number`
+
+Override value for the `trialDays` config option. Only applies to recurring purchases.
+
 ## Return
 
 ### if `returnObject` parameter is `false` (default)

--- a/docs/reference/billing/request.md
+++ b/docs/reference/billing/request.md
@@ -136,7 +136,7 @@ Which URL to redirect the merchant to after the charge is confirmed.
 
 Whether to return the `confirmationUrl` as a `string`, or to return a more detailed object (see below).
 
-### trialDaysOverride
+### trialDays
 
 `number`
 

--- a/lib/billing/__tests__/request.test.ts
+++ b/lib/billing/__tests__/request.test.ts
@@ -407,4 +407,72 @@ describe('shopify.billing.request', () => {
       });
     });
   });
+
+  it('applies trialDays override when set', async () => {
+    shopify = shopifyApi({
+      ...testConfig,
+      billing: {
+        [Responses.PLAN_1]: {
+          amount: 5,
+          currencyCode: 'USD',
+          interval: BillingInterval.Every30Days,
+          replacementBehavior: BillingReplacementBehavior.ApplyImmediately,
+          trialDays: 10,
+        },
+      },
+    });
+
+    queueMockResponses([Responses.PURCHASE_SUBSCRIPTION_RESPONSE]);
+
+    await shopify.billing.request({
+      session,
+      plan: Responses.PLAN_1,
+      returnObject: true,
+      trialDaysOverride: 20,
+    });
+
+    expect({
+      ...GRAPHQL_BASE_REQUEST,
+      data: {
+        query: expect.stringContaining('appSubscriptionCreate'),
+        variables: expect.objectContaining({
+          trialDays: 20,
+        }),
+      },
+    }).toMatchMadeHttpRequest();
+  });
+
+  it('applies a trialDays override of 0', async () => {
+    shopify = shopifyApi({
+      ...testConfig,
+      billing: {
+        [Responses.PLAN_1]: {
+          amount: 5,
+          currencyCode: 'USD',
+          interval: BillingInterval.Every30Days,
+          replacementBehavior: BillingReplacementBehavior.ApplyImmediately,
+          trialDays: 10,
+        },
+      },
+    });
+
+    queueMockResponses([Responses.PURCHASE_SUBSCRIPTION_RESPONSE]);
+
+    await shopify.billing.request({
+      session,
+      plan: Responses.PLAN_1,
+      returnObject: true,
+      trialDaysOverride: 0,
+    });
+
+    expect({
+      ...GRAPHQL_BASE_REQUEST,
+      data: {
+        query: expect.stringContaining('appSubscriptionCreate'),
+        variables: expect.objectContaining({
+          trialDays: 0,
+        }),
+      },
+    }).toMatchMadeHttpRequest();
+  });
 });

--- a/lib/billing/__tests__/request.test.ts
+++ b/lib/billing/__tests__/request.test.ts
@@ -428,7 +428,7 @@ describe('shopify.billing.request', () => {
       session,
       plan: Responses.PLAN_1,
       returnObject: true,
-      trialDaysOverride: 20,
+      trialDays: 20,
     });
 
     expect({
@@ -462,7 +462,7 @@ describe('shopify.billing.request', () => {
       session,
       plan: Responses.PLAN_1,
       returnObject: true,
-      trialDaysOverride: 0,
+      trialDays: 0,
     });
 
     expect({

--- a/lib/billing/request.ts
+++ b/lib/billing/request.ts
@@ -29,7 +29,7 @@ interface RequestInternalParams {
 
 interface RequestSubscriptionInternalParams extends RequestInternalParams {
   billingConfig: BillingConfigSubscriptionPlan;
-  trialDaysOverride?: number;
+  trialDays?: number;
 }
 
 interface RequestOneTimePaymentInternalParams extends RequestInternalParams {
@@ -38,7 +38,7 @@ interface RequestOneTimePaymentInternalParams extends RequestInternalParams {
 
 interface RequestUsageSubscriptionInternalParams extends RequestInternalParams {
   billingConfig: BillingConfigUsagePlan;
-  trialDaysOverride?: number;
+  trialDays?: number;
 }
 
 export function request(config: ConfigInterface) {
@@ -48,7 +48,7 @@ export function request(config: ConfigInterface) {
     isTest = true,
     returnUrl: returnUrlParam,
     returnObject = false,
-    trialDaysOverride = undefined,
+    trialDays = undefined,
   }: Params): Promise<BillingRequestResponse<Params>> {
     if (!config.billing || !config.billing[plan]) {
       throw new BillingError({
@@ -93,7 +93,7 @@ export function request(config: ConfigInterface) {
           client,
           returnUrl,
           isTest,
-          trialDaysOverride,
+          trialDays,
         });
         data = mutationUsageResponse.data.appSubscriptionCreate;
         break;
@@ -105,7 +105,7 @@ export function request(config: ConfigInterface) {
           client,
           returnUrl,
           isTest,
-          trialDaysOverride,
+          trialDays,
         });
         data = mutationRecurringResponse.data.appSubscriptionCreate;
       }
@@ -134,18 +134,16 @@ async function requestRecurringPayment({
   client,
   returnUrl,
   isTest,
-  trialDaysOverride,
+  trialDays,
 }: RequestSubscriptionInternalParams): Promise<RecurringPaymentResponse> {
-  const trialDays =
-    trialDaysOverride === undefined
-      ? billingConfig.trialDays
-      : trialDaysOverride;
+  const trialDaysValue =
+    trialDays === undefined ? billingConfig.trialDays : trialDays;
   const mutationResponse = await client.query<RecurringPaymentResponse>({
     data: {
       query: RECURRING_PURCHASE_MUTATION,
       variables: {
         name: plan,
-        trialDays,
+        trialDays: trialDaysValue,
         replacementBehavior: billingConfig.replacementBehavior,
         returnUrl,
         test: isTest,
@@ -190,12 +188,10 @@ async function requestUsagePayment({
   client,
   returnUrl,
   isTest,
-  trialDaysOverride,
+  trialDays,
 }: RequestUsageSubscriptionInternalParams): Promise<RecurringPaymentResponse> {
-  const trialDays =
-    trialDaysOverride === undefined
-      ? billingConfig.trialDays
-      : trialDaysOverride;
+  const trialDaysValue =
+    trialDays === undefined ? billingConfig.trialDays : trialDays;
   const mutationResponse = await client.query<RecurringPaymentResponse>({
     data: {
       query: RECURRING_PURCHASE_MUTATION,
@@ -203,7 +199,7 @@ async function requestUsagePayment({
         name: plan,
         returnUrl,
         test: isTest,
-        trialDays,
+        trialDays: trialDaysValue,
         replacementBehavior: billingConfig.replacementBehavior,
         lineItems: [
           {

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -74,7 +74,7 @@ export interface BillingRequestParams {
   isTest?: boolean;
   returnUrl?: string;
   returnObject?: boolean;
-  trialDaysOverride?: number;
+  trialDays?: number;
 }
 
 export interface BillingRequestResponseObject {

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -74,6 +74,7 @@ export interface BillingRequestParams {
   isTest?: boolean;
   returnUrl?: string;
   returnObject?: boolean;
+  trialDaysOverride?: number;
 }
 
 export interface BillingRequestResponseObject {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #958 

The billing API resets trials when the app is uninstalled by design, to allow more control for apps. Therefore, it falls to the app to keep track of how many trial days to grant a merchant when they set up a subscription.

However, currently the `request` method will always apply the config's `trialDays` setting, which means apps don't get to control the number of days.

### WHAT is this pull request doing?

Adding a `trialDaysOverride` parameter to `request`, which will enable apps to have full control over the value that gets effectively sent to the API.

A couple of questions for the reviewer:
1. Should we just name the new param `trialDays`?
1. Should we have the `request` param extend `Partial<BillingConfig>`, so that apps can override every field when calling the method?

I went with the most explicit settings here because I was concerned it might be confusing for users whether they'd need a config at all (spoilers: they do).

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
