### PR TITLE
Enable private SF API access tokens

### DIFF
--- a/.changeset/unlucky-boats-stare.md
+++ b/.changeset/unlucky-boats-stare.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Allow using Session objects to create Storefront API clients that make requests using private access tokens.

--- a/docs/reference/clients/Storefront.md
+++ b/docs/reference/clients/Storefront.md
@@ -2,11 +2,11 @@
 
 Instances of this class can make requests to the Shopify Storefront API.
 
-> **Note**: ⚠️ This API limits request rates based on the IP address that calls it, which will be your server's address for all requests made by the library. The API uses a leaky bucket algorithm, with a default bucket size of 60 seconds of request processing time (minimum 0.5s per request), with a leak rate of 1/s. Learn more about [rate limits](https://shopify.dev/docs/api/usage/rate-limits).
+> **Note**: ⚠️ This API limits request rates based on the IP address that calls it. This API uses a leaky bucket algorithm, with a default bucket size of 60 seconds of request processing time (minimum 0.5s per request), with a leak rate of 1/s. Learn more about [rate limits](https://shopify.dev/docs/api/usage/rate-limits).
 
 ## Requirements
 
-You can create Storefront API access tokens for both **private apps** and **sales channels**, but you **must use offline access tokens** for sales channels. Please read [our documentation](https://shopify.dev/docs/custom-storefronts/building-with-the-storefront-api/products-collections/getting-started) to learn more about Storefront Access Tokens.
+You can authenticate with the Storefront API using either [public or private access tokens](https://shopify.dev/docs/api/storefront#authentication). This package always runs on an app's backend, so you should prefer private access tokens when making requests to the API.
 
 If you are building a private app, you can set a default Storefront Access Token for all `Storefront` client instances by setting the `config.privateAppStorefrontAccessToken` property when calling [`shopifyApi`](../shopifyApi.md).
 
@@ -14,10 +14,9 @@ If you are building a private app, you can set a default Storefront Access Token
 
 ### Example
 
-Below is a (simplified) example of how you may create a token and construct a client.
-See the [REST](https://shopify.dev/docs/api/admin-rest/latest/resources/storefrontaccesstoken) or [GraphQL](https://shopify.dev/docs/api/admin-graphql/latest/mutations/storefrontAccessTokenCreate) Admin API references for more information.
+Below is an example of how you may construct this client, using the same `Session` object as the [Admin API client](./Graphql.md).
 
-Once you've created your access token, you can query the Storefront API based on the `unauthenticated_*` scopes your app requests.
+To query this API, your app will need to set the appropriate `unauthenticated_*` scopes when going through OAuth.
 See the [API reference documentation](https://shopify.dev/docs/api/storefront) for detailed instructions on each component.
 
 ```ts
@@ -29,27 +28,11 @@ app.get('/my-endpoint', async (req, res) => {
   });
 
   // use sessionId to retrieve session from app's session storage
-  // getSessionFromStorage() must be provided by application
+  // getSessionFromStorage() must be provided by the application
   const session = await getSessionFromStorage(sessionId);
 
-  const adminApiClient = new shopify.clients.Rest({session});
-  const storefrontTokenResponse = await adminApiClient.post({
-    path: 'storefront_access_tokens',
-    data: {
-      storefront_access_token: {
-        title: 'This is my test access token',
-      },
-    },
-  });
-
-  const storefrontAccessToken =
-    storefrontTokenResponse.body.storefront_access_token.access_token;
-
-  // For simplicity, this example creates a token every time it's called, but that is not ideal.
-  // You can fetch existing Storefront access tokens using the Admin API client.
-  const storefrontClient = new shopify.clients.Storefront({
-    domain: session.shop,
-    storefrontAccessToken,
+  const client = new shopify.clients.Storefront({
+    session,
     apiVersion: ApiVersion.January23,
   });
 });
@@ -59,17 +42,11 @@ app.get('/my-endpoint', async (req, res) => {
 
 Receives an object containing:
 
-#### domain
+#### session
 
-`string` | :exclamation: required
+`Session` | :exclamation: required for non-Custom store apps
 
-The shop domain for the request.
-
-#### storefrontAccessToken
-
-`string` | :exclamation: required
-
-The access token created using one of the Admin APIs.
+The session for the request.
 
 #### apiVersion
 

--- a/lib/clients/graphql/graphql_client.ts
+++ b/lib/clients/graphql/graphql_client.ts
@@ -95,13 +95,24 @@ export class GraphqlClient {
   }
 
   protected getApiHeaders(): HeaderParams {
-    const customStoreAppAccessToken =
-      this.graphqlClass().config.adminApiAccessToken ??
-      this.graphqlClass().config.apiSecretKey;
+    const {config} = this.graphqlClass();
+
+    let accessToken: string | undefined;
+    if (config.isCustomStoreApp) {
+      // Deprecated: starting in v8, we should only get the token from adminApiAccessToken
+      accessToken = config.adminApiAccessToken ?? config.apiSecretKey;
+    } else {
+      accessToken = this.session.accessToken;
+
+      if (!accessToken) {
+        throw new ShopifyErrors.MissingRequiredArgument(
+          'Session missing access token.',
+        );
+      }
+    }
+
     return {
-      [ShopifyHeader.AccessToken]: this.graphqlClass().config.isCustomStoreApp
-        ? customStoreAppAccessToken
-        : (this.session.accessToken as string),
+      [ShopifyHeader.AccessToken]: accessToken,
     };
   }
 

--- a/lib/clients/graphql/storefront_client.ts
+++ b/lib/clients/graphql/storefront_client.ts
@@ -4,23 +4,39 @@ import {httpClientClass} from '../http_client/http_client';
 import {Session} from '../../session/session';
 import {HeaderParams} from '../http_client/types';
 import {logger} from '../../logger';
+import {MissingRequiredArgument} from '../../error';
+import {enableCodeAfterVersion} from '../../utils/versioned-codeblocks';
 
 import {GraphqlClient, GraphqlClientClassParams} from './graphql_client';
-import {StorefrontClientParams} from './types';
+import {DeprecatedStorefrontClientParams, GraphqlClientParams} from './types';
 
 export class StorefrontClient extends GraphqlClient {
   baseApiPath = '/api';
+  readonly session: Session;
+  /** @deprecated This package should not use public Storefront API tokens. Use `session` instead. */
   readonly domain: string;
+  /** @deprecated This package should not use public Storefront API tokens. Use `session` instead. */
   readonly storefrontAccessToken: string;
 
-  constructor(params: StorefrontClientParams) {
-    const session = new Session({
-      shop: params.domain,
-      id: '',
-      state: '',
-      isOnline: true,
-      accessToken: params.storefrontAccessToken,
-    });
+  /** @deprecated This package should not use public Storefront API tokens */
+  private readonly tokenHeader:
+    | ShopifyHeader.StorefrontPrivateToken
+    | ShopifyHeader.StorefrontAccessToken =
+    ShopifyHeader.StorefrontPrivateToken;
+
+  constructor(params: GraphqlClientParams | DeprecatedStorefrontClientParams) {
+    let session: Session;
+    if (isDeprecatedParamsType(params)) {
+      session = new Session({
+        shop: params.domain,
+        id: '',
+        state: '',
+        isOnline: true,
+        accessToken: params.storefrontAccessToken,
+      });
+    } else {
+      session = params.session;
+    }
 
     super({session, apiVersion: params.apiVersion});
 
@@ -35,30 +51,48 @@ export class StorefrontClient extends GraphqlClient {
       logger(config).debug(message);
     }
 
-    this.domain = params.domain;
-    this.storefrontAccessToken = params.storefrontAccessToken;
-  }
-
-  protected getApiHeaders(): HeaderParams {
-    const sdkVariant = LIBRARY_NAME.toLowerCase().split(' ').join('-');
-    const privateToken =
-      this.storefrontClass().config.privateAppStorefrontAccessToken;
-
-    if (this.storefrontAccessToken && privateToken) {
-      logger(this.storefrontClass().config).warning(
-        'You have both private and public storefront access tokens. The private token will be used.',
+    if (isDeprecatedParamsType(params)) {
+      this.tokenHeader = ShopifyHeader.StorefrontAccessToken;
+      this.storefrontAccessToken = params.storefrontAccessToken;
+      logger(config).deprecated(
+        '8.0.0',
+        [
+          'The domain and storefrontAccessToken params are deprecated, because they assume public access tokens for the Storefront API.',
+          'Apps should not use public Storefront API tokens for backend requests. Pass the session param instead.',
+          'See https://shopify.dev/docs/api/usage/authentication#access-tokens-for-the-storefront-api for more information.',
+        ].join('\n'),
       );
     }
 
-    const tokenHeaderParam =
-      privateToken === undefined
-        ? {[ShopifyHeader.StorefrontAccessToken]: this.storefrontAccessToken}
-        : ({
-            [ShopifyHeader.StorefrontPrivateToken]: privateToken,
-          } as HeaderParams);
+    this.session = session;
+  }
 
+  protected getApiHeaders(): HeaderParams {
+    const config = this.storefrontClass().config;
+
+    let accessToken: string | undefined;
+    if (config.isCustomStoreApp) {
+      accessToken = config.privateAppStorefrontAccessToken;
+
+      if (!accessToken) {
+        enableCodeAfterVersion('8.0.0', () => {
+          throw new MissingRequiredArgument(
+            'Custom store apps must set the privateAppStorefrontAccessToken property to call the Storefront API.',
+          );
+        });
+        accessToken = this.session.accessToken || this.storefrontAccessToken;
+      }
+    } else {
+      accessToken = this.session.accessToken;
+
+      if (!accessToken) {
+        throw new MissingRequiredArgument('Session missing access token.');
+      }
+    }
+
+    const sdkVariant = LIBRARY_NAME.toLowerCase().split(' ').join('-');
     return {
-      ...tokenHeaderParam,
+      [this.tokenHeader]: accessToken,
       [ShopifyHeader.StorefrontSDKVariant]: sdkVariant,
       [ShopifyHeader.StorefrontSDKVersion]: SHOPIFY_API_LIBRARY_VERSION,
     };
@@ -85,4 +119,10 @@ export function storefrontClientClass(params: GraphqlClientClassParams) {
   });
 
   return NewStorefrontClient as typeof StorefrontClient;
+}
+
+function isDeprecatedParamsType(
+  params: GraphqlClientParams | DeprecatedStorefrontClientParams,
+): params is DeprecatedStorefrontClientParams {
+  return 'domain' in params;
 }

--- a/lib/clients/graphql/types.ts
+++ b/lib/clients/graphql/types.ts
@@ -9,7 +9,7 @@ export interface GraphqlClientParams {
   apiVersion?: ApiVersion;
 }
 
-export interface StorefrontClientParams {
+export interface DeprecatedStorefrontClientParams {
   domain: string;
   storefrontAccessToken: string;
   apiVersion?: ApiVersion;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -26,6 +26,7 @@ export enum ShopifyHeader {
   Hmac = 'X-Shopify-Hmac-Sha256',
   Topic = 'X-Shopify-Topic',
   WebhookId = 'X-Shopify-Webhook-Id',
+  /** @deprecated This is a backend package and it should never call the SFAPI using public tokens */
   StorefrontAccessToken = 'X-Shopify-Storefront-Access-Token',
   StorefrontPrivateToken = 'Shopify-Storefront-Private-Token',
   StorefrontSDKVariant = 'X-SDK-Variant',


### PR DESCRIPTION
### WHY are these changes introduced?

In the initial implementation of the SF API client, we only had the option of using what are now public access tokens (created via the Admin API). Now that we allow private tokens, we should only be using those (since this package is only meant for backend apps).

### WHAT is this pull request doing?

Adding support for passing in a `Session` object to the Storefront client, which is the same session used by the Admin client, instead of the shop / public access token pair. If the session is used, the client will make requests with the private access token header.

The previous params are now deprecated since this package should never make public token requests.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
