### PR TITLE
Fixed publishing for shopify-api package

### DIFF
--- a/.changeset/poor-books-do.md
+++ b/.changeset/poor-books-do.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Fixing publishing process to prevent empty packages

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "turbo build --filter=docs^... && changeset publish",
+    "release": "turbo build && changeset publish",
     "test": "turbo run test --parallel",
     "test:ci": "turbo run test:ci --parallel"
   },


### PR DESCRIPTION
This PR fixes an issue with our publishing pipeline that lead to an empty 8.0.0 package being published.