### PR TITLE
Removed unnecessary shopify-api change

### DIFF
--- a/.changeset/cyan-tigers-care.md
+++ b/.changeset/cyan-tigers-care.md
@@ -1,6 +1,5 @@
 ---
 "@shopify/graphql-client": minor
-"@shopify/shopify-api": patch
 ---
 
 Added a new `graphql-client` package. This client is a generic GQL client that provides basic functionalities to interact with Shopify's GraphQL APIs.


### PR DESCRIPTION
### WHY are these changes introduced?
Removes the unnecessary `shopify-api` version change from changeset.

