### PR TITLE
[GraphQL Client] Fix ResponseWithType to correctly type the json() return value

### DIFF
--- a/.changeset/gentle-books-dress.md
+++ b/.changeset/gentle-books-dress.md
@@ -1,0 +1,5 @@
+---
+"@shopify/graphql-client": patch
+---
+
+Fix `ResponseWithType` to correctly type the `json` return value

--- a/packages/graphql-client/src/api-client-utilities/operation-types.ts
+++ b/packages/graphql-client/src/api-client-utilities/operation-types.ts
@@ -25,7 +25,7 @@ export type OperationVariables<
       };
     };
 
-export type ResponseWithType<T = any> = Response & {
+export type ResponseWithType<T = any> = Omit<Response, "json"> & {
   json: () => Promise<T>;
 };
 


### PR DESCRIPTION
### WHY are these changes introduced?
Fix `ResponseWithType` to correctly type the `json()` return value

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
