### PR TITLE
Link to the v9 migration guide from changelog

### DIFF
--- a/.changeset/rich-ladybugs-own.md
+++ b/.changeset/rich-ladybugs-own.md
@@ -9,3 +9,5 @@
 Changed `setAbstractFetchFunc` to accept a `fetch` API instead of one based on `NormalizedRequest` and `NormalizedResponse`.
 
 With this change, we can return a `Response` object for requests with the upcoming clients, which can help make the interface for requests more familiar to users.
+
+For more information and examples, see the [migration guide to v9](https://github.com/Shopify/shopify-api-js/blob/fix_adapter_fetch_link_to_guide/packages/shopify-api/docs/migrating-to-v9.md#changes-to-runtime-adapters).


### PR DESCRIPTION
This PR is just completing the work in #1067 to link to the migration guide from the changelog.