### PR TITLE
Add withinMillisecondsOfExpiry param to mark session as expired within specified milliseconds of expiry

### DIFF
--- a/.changeset/fast-jokes-protect.md
+++ b/.changeset/fast-jokes-protect.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": minor
+---
+
+Allow access tokens to be marked as expired before actual expiry.

--- a/packages/shopify-api/lib/session/__tests__/session.test.ts
+++ b/packages/shopify-api/lib/session/__tests__/session.test.ts
@@ -87,7 +87,31 @@ describe('isExpired', () => {
     expect(session.isExpired()).toBeTruthy();
   });
 
-  it('returns false if session is expired', () => {
+  it('returns true if session expiry is within specified value', () => {
+    const session = new Session({
+      id: 'not_active',
+      shop: 'inactive-shop',
+      state: 'not_same',
+      isOnline: true,
+      scope: 'test_scope',
+      expires: new Date(Date.now() + 55000),
+    });
+    expect(session.isExpired(60000)).toBeTruthy();
+  });
+
+  it('returns false if session expiry is not within specified value', () => {
+    const session = new Session({
+      id: 'not_active',
+      shop: 'inactive-shop',
+      state: 'not_same',
+      isOnline: true,
+      scope: 'test_scope',
+      expires: new Date(Date.now() + 75000),
+    });
+    expect(session.isExpired(60000)).toBeFalsy();
+  });
+
+  it('returns false if session is not expired', () => {
     const session = new Session({
       id: 'active',
       shop: 'active-shop',

--- a/packages/shopify-api/lib/session/session.ts
+++ b/packages/shopify-api/lib/session/session.ts
@@ -103,8 +103,11 @@ export class Session {
     return !scopesObject.equals(this.scope);
   }
 
-  public isExpired(): boolean {
-    return Boolean(this.expires && this.expires < new Date());
+  public isExpired(withinMillisecondsOfExpiry = 0): boolean {
+    return Boolean(
+      this.expires &&
+        this.expires.getTime() - withinMillisecondsOfExpiry < Date.now(),
+    );
   }
 
   public toObject(): SessionParams {


### PR DESCRIPTION
### WHY are these changes introduced?

Allows access tokens to be marked as expired before actual expiry. This will be useful for apps to not use an access token if it's about to expire.

### WHAT is this pull request doing?

Uses `withinMillisecondsOfExpiry` (default 0) to determine how long before the set expiration time the token should be marked as expired. 

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
