### PR TITLE
[API Clients] Update log types for consistent log type format

### DIFF
--- a/.changeset/soft-llamas-rush.md
+++ b/.changeset/soft-llamas-rush.md
@@ -1,0 +1,7 @@
+---
+"@shopify/storefront-api-client": minor
+"@shopify/admin-api-client": minor
+"@shopify/graphql-client": minor
+---
+
+Update `UNSUPPORTED_API_VERSION` log type to `Unsupported_Api_Version` for consistent log type format

--- a/packages/admin-api-client/README.md
+++ b/packages/admin-api-client/README.md
@@ -334,7 +334,7 @@ This log content is sent to the logger whenever an unsupported API version is pr
 
 | Property | Type                     | Description                        |
 | -------- | ------------------------ | ---------------------------------- |
-| type      | `LogType['UNSUPPORTED_API_VERSION']`                 | The type of log content. Is always set to `UNSUPPORTED_API_VERSION`            |
+| type      | `LogType['Unsupported_Api_Version']`                 | The type of log content. Is always set to `Unsupported_Api_Version`            |
 | content  | `{apiVersion: string, supportedApiVersions: string[]}` | Contextual info including the provided API version and the list of currently supported API versions. |
 
 ### `HTTPResponseLog`

--- a/packages/graphql-client/src/api-client-utilities/tests/validation.test.ts
+++ b/packages/graphql-client/src/api-client-utilities/tests/validation.test.ts
@@ -148,7 +148,7 @@ describe("validateRequiredApiVersion()", () => {
     );
   });
 
-  it("logs an UNSUPPORTED_API_VERSION log object when a logger is provided and the api version is not supported", () => {
+  it("logs an Unsupported_Api_Version log object when a logger is provided and the api version is not supported", () => {
     const apiVersion = "2021-10";
     const logger = jest.fn();
 
@@ -160,7 +160,7 @@ describe("validateRequiredApiVersion()", () => {
     });
 
     expect(logger).toHaveBeenCalledWith({
-      type: "UNSUPPORTED_API_VERSION",
+      type: "Unsupported_Api_Version",
       content: {
         apiVersion,
         supportedApiVersions: mockApiVersions,

--- a/packages/graphql-client/src/api-client-utilities/types.ts
+++ b/packages/graphql-client/src/api-client-utilities/types.ts
@@ -23,7 +23,7 @@ export {
 } from "./operation-types";
 
 export interface UnsupportedApiVersionLog extends LogContent {
-  type: "UNSUPPORTED_API_VERSION";
+  type: "Unsupported_Api_Version";
   content: {
     apiVersion: string;
     supportedApiVersions: string[];

--- a/packages/graphql-client/src/api-client-utilities/validations.ts
+++ b/packages/graphql-client/src/api-client-utilities/validations.ts
@@ -54,7 +54,7 @@ export function validateApiVersion({
   if (!currentSupportedApiVersions.includes(trimmedApiVersion)) {
     if (logger) {
       logger({
-        type: "UNSUPPORTED_API_VERSION",
+        type: "Unsupported_Api_Version",
         content: {
           apiVersion,
           supportedApiVersions: currentSupportedApiVersions,

--- a/packages/storefront-api-client/README.md
+++ b/packages/storefront-api-client/README.md
@@ -395,7 +395,7 @@ This log content is sent to the logger whenever an unsupported API version is pr
 
 | Property | Type                     | Description                        |
 | -------- | ------------------------ | ---------------------------------- |
-| type      | `LogType['UNSUPPORTED_API_VERSION']`                 | The type of log content. Is always set to `UNSUPPORTED_API_VERSION`            |
+| type      | `LogType['Unsupported_Api_Version']`                 | The type of log content. Is always set to `Unsupported_Api_Version`            |
 | content  | `{apiVersion: string, supportedApiVersions: string[]}` | Contextual info including the provided API version and the list of currently supported API versions. |
 
 ### `HTTPResponseLog`


### PR DESCRIPTION
### WHY are these changes introduced?
To ensure the format of the `LogTypes` are consistent through all the clients, we're updating the `UNSUPPORTED_API_VERSION` to `Unsupported_Api_Version ` to match the existing HTTP log type (i.e. `HTTP-Response` and `HTTP-Retry`) formats.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
