### PR TITLE
[GraphQL Client] Rename graphql-client's fetchApi to customFetchApi

### DIFF
--- a/.changeset/real-turtles-cover.md
+++ b/.changeset/real-turtles-cover.md
@@ -1,0 +1,5 @@
+---
+"@shopify/graphql-client": patch
+---
+
+Rename `fetchApi` parameter to `customFetchApi` for clarity

--- a/packages/admin-api-client/src/graphql/client.ts
+++ b/packages/admin-api-client/src/graphql/client.ts
@@ -27,7 +27,7 @@ export function createAdminApiClient({
   accessToken,
   userAgentPrefix,
   retries = 0,
-  customFetchApi: clientFetchApi,
+  customFetchApi,
   logger,
 }: AdminApiClientOptions): AdminApiClient {
   const currentSupportedApiVersions = getCurrentSupportedApiVersions();
@@ -78,7 +78,7 @@ export function createAdminApiClient({
     headers: config.headers,
     url: config.apiUrl,
     retries,
-    fetchApi: clientFetchApi,
+    customFetchApi,
     logger,
   });
 

--- a/packages/admin-api-client/src/graphql/tests/client.test.ts
+++ b/packages/admin-api-client/src/graphql/tests/client.test.ts
@@ -111,7 +111,7 @@ describe("Admin API Client", () => {
         expect(createGraphQLClient).toHaveBeenCalled();
         expect(
           (createGraphQLClient as jest.Mock).mock.calls[0][0],
-        ).toHaveProperty("fetchApi", customFetchApi);
+        ).toHaveProperty("customFetchApi", customFetchApi);
       });
 
       it("calls the graphql client with the provided logger", () => {

--- a/packages/admin-api-client/src/rest/client.ts
+++ b/packages/admin-api-client/src/rest/client.ts
@@ -79,7 +79,7 @@ export function createAdminRestApiClient({
   );
   const clientLogger = generateClientLogger(logger);
   const httpFetch = generateHttpFetch({
-    fetchApi: customFetchApi,
+    customFetchApi,
     clientLogger,
     defaultRetryWaitTime: defaultRetryTime,
     client: CLIENT,

--- a/packages/graphql-client/README.md
+++ b/packages/graphql-client/README.md
@@ -40,7 +40,7 @@ const client = createGraphQLClient({
     'Content-Type': 'application/json',
     'X-Shopify-Storefront-Access-Token': 'public-token',
   },
-  customFetchApi: fetch
+  customFetchApi: nodeFetch
 });
 ```
 

--- a/packages/graphql-client/README.md
+++ b/packages/graphql-client/README.md
@@ -26,6 +26,24 @@ const client = createGraphQLClient({
 });
 ```
 
+### Create a server enabled client using a custom Fetch API
+
+In order to use the client within a server, a server enabled JS Fetch API will need to be provided to the client at initialization. By default, the client uses `window.fetch` for network requests.
+
+```typescript
+import {createGraphQLClient} from '@shopify/graphql-client';
+import {fetch as nodeFetch} from 'node-fetch';
+
+const client = createGraphQLClient({
+  url: 'http://your-shop-name.myshopify.com/api/2023-10/graphql.json',
+  headers: {
+    'Content-Type': 'application/json',
+    'X-Shopify-Storefront-Access-Token': 'public-token',
+  },
+  customFetchApi: fetch
+});
+```
+
 ### `createGraphQLClient()` parameters
 
 | Property | Type                     | Description                        |
@@ -33,7 +51,7 @@ const client = createGraphQLClient({
 | url      | `string`                 | The GraphQL API URL             |
 | headers  | `{[key: string]: string}` | Headers to be included in requests |
 | retries?  | `number` | The number of HTTP request retries if the request was abandoned or the server responded with a `Too Many Requests (429)` or `Service Unavailable (503)` response. Default value is `0`. Maximum value is `3`. |
-| fetchApi?  | `(url: string, init?: {method?: string, headers?: HeaderInit, body?: string}) => Promise<Response>` | A replacement `fetch` function that will be used in all client network requests. By default, the client uses `window.fetch()`. |
+| customFetchApi?  | `(url: string, init?: {method?: string, headers?: HeaderInit, body?: string}) => Promise<Response>` | A replacement `fetch` function that will be used in all client network requests. By default, the client uses `window.fetch()`. |
 | logger?  | `(logContent: `[`HTTPResponseLog`](#httpresponselog)`\|`[`HTTPRetryLog`](#httpretrylog)`) => void` | A logger function that accepts [log content objects](#log-content-types). This logger will be called in certain conditions with contextual information.  |
 
 ## Client properties

--- a/packages/graphql-client/src/graphql-client/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client/graphql-client.ts
@@ -26,7 +26,7 @@ import {
 export function createGraphQLClient({
   headers,
   url,
-  fetchApi = fetch,
+  customFetchApi = fetch,
   retries = 0,
   logger,
 }: ClientOptions): GraphQLClient {
@@ -40,7 +40,7 @@ export function createGraphQLClient({
 
   const clientLogger = generateClientLogger(logger);
   const httpFetch = generateHttpFetch({
-    fetchApi,
+    customFetchApi,
     clientLogger,
     defaultRetryWaitTime: RETRY_WAIT_TIME,
   });

--- a/packages/graphql-client/src/graphql-client/http-fetch.ts
+++ b/packages/graphql-client/src/graphql-client/http-fetch.ts
@@ -4,7 +4,7 @@ import { formatErrorMessage, getErrorMessage } from "./utilities";
 
 interface GenerateHttpFetchOptions {
   clientLogger: Logger;
-  fetchApi?: CustomFetchApi;
+  customFetchApi?: CustomFetchApi;
   client?: string;
   defaultRetryWaitTime?: number;
   retriableCodes?: number[];
@@ -12,7 +12,7 @@ interface GenerateHttpFetchOptions {
 
 export function generateHttpFetch({
   clientLogger,
-  fetchApi = fetch,
+  customFetchApi = fetch,
   client = CLIENT,
   defaultRetryWaitTime = RETRY_WAIT_TIME,
   retriableCodes = RETRIABLE_STATUS_CODES,
@@ -27,7 +27,7 @@ export function generateHttpFetch({
     let response: Response | undefined;
 
     try {
-      response = await fetchApi(...requestParams);
+      response = await customFetchApi(...requestParams);
 
       clientLogger({
         type: "HTTP-Response",

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client.test.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client.test.ts
@@ -140,7 +140,7 @@ describe("GraphQL Client", () => {
 
         const client = createGraphQLClient({
           ...config,
-          fetchApi: customFetchApi,
+          customFetchApi,
         });
 
         const props: [string, RequestOptions] = [
@@ -277,7 +277,7 @@ describe("GraphQL Client", () => {
 
         const client = createGraphQLClient({
           ...config,
-          fetchApi: customFetchApi,
+          customFetchApi,
         });
 
         const props: [string, RequestOptions] = [

--- a/packages/graphql-client/src/graphql-client/tests/http-fetch.test.ts
+++ b/packages/graphql-client/src/graphql-client/tests/http-fetch.test.ts
@@ -62,7 +62,7 @@ describe("httpFetch utility", () => {
         );
 
         const httpFetch = generateHttpFetch({
-          fetchApi: mockFetch,
+          customFetchApi: mockFetch,
           clientLogger,
         });
 

--- a/packages/graphql-client/src/graphql-client/types.ts
+++ b/packages/graphql-client/src/graphql-client/types.ts
@@ -61,7 +61,7 @@ export type Logger<TLogContentTypes = LogContentTypes> = (
 export interface ClientOptions {
   headers: Headers;
   url: string;
-  fetchApi?: CustomFetchApi;
+  customFetchApi?: CustomFetchApi;
   retries?: number;
   logger?: Logger;
 }

--- a/packages/shopify-api/adapters/__e2etests__/test_handle_graphql.ts
+++ b/packages/shopify-api/adapters/__e2etests__/test_handle_graphql.ts
@@ -15,7 +15,7 @@ function graphqlClientFactory(apiServer: string) {
   return createGraphQLClient({
     url: `http://${apiServer}`,
     headers: {},
-    fetchApi: abstractFetch,
+    customFetchApi: abstractFetch,
   });
 }
 

--- a/packages/storefront-api-client/src/storefront-api-client.ts
+++ b/packages/storefront-api-client/src/storefront-api-client.ts
@@ -36,7 +36,7 @@ export function createStorefrontApiClient({
   privateAccessToken,
   clientName,
   retries = 0,
-  customFetchApi: clientFetchApi,
+  customFetchApi,
   logger,
 }: StorefrontApiClientOptions): StorefrontApiClient {
   const currentSupportedApiVersions = getCurrentSupportedApiVersions();
@@ -88,7 +88,7 @@ export function createStorefrontApiClient({
     headers: config.headers,
     url: config.apiUrl,
     retries,
-    fetchApi: clientFetchApi,
+    customFetchApi,
     logger,
   });
 

--- a/packages/storefront-api-client/src/tests/storefront-api-client/storefront-api-client.test.ts
+++ b/packages/storefront-api-client/src/tests/storefront-api-client/storefront-api-client.test.ts
@@ -92,7 +92,7 @@ describe("Storefront API Client", () => {
         expect(createGraphQLClient).toHaveBeenCalled();
         expect(
           (createGraphQLClient as jest.Mock).mock.calls[0][0],
-        ).toHaveProperty("fetchApi", customFetchApi);
+        ).toHaveProperty("customFetchApi", customFetchApi);
       });
 
       it("calls the graphql client with the provided logger", () => {


### PR DESCRIPTION
### WHY are these changes introduced?
To maintain consistent parameter and property naming between the various clients, we're renaming `graphql-client's` `fetchApi` prop name to `customFetchApi`

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
