### PR TITLE
Fix some small issues in underpinned REST client

### DIFF
--- a/.changeset/rude-moose-flash.md
+++ b/.changeset/rude-moose-flash.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Fixed an issue in the `RestClient` class' `request` method, which was incorrectly made `private` instead of `protected.`

--- a/packages/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/shopify-api/lib/clients/admin/graphql/client.ts
@@ -123,7 +123,7 @@ export class GraphqlClient {
 
     if (response.errors) {
       const fetchResponse = response.errors.response!;
-      throwFailedRequest(response, fetchResponse, false);
+      throwFailedRequest(response, fetchResponse, (options?.retries ?? 0) > 0);
     }
 
     return response;

--- a/packages/shopify-api/lib/clients/admin/rest/client.ts
+++ b/packages/shopify-api/lib/clients/admin/rest/client.ts
@@ -122,7 +122,7 @@ export class RestClient {
     return this.request<T>({method: Method.Delete, ...params});
   }
 
-  private async request<T = any>(
+  protected async request<T = any>(
     params: RequestParams,
   ): Promise<RestRequestReturn<T>> {
     const requestParams = {

--- a/packages/shopify-api/lib/clients/storefront/client.ts
+++ b/packages/shopify-api/lib/clients/storefront/client.ts
@@ -138,7 +138,7 @@ export class StorefrontClient {
 
     if (response.errors) {
       const fetchResponse = response.errors.response!;
-      throwFailedRequest(response, fetchResponse, false);
+      throwFailedRequest(response, fetchResponse, (options?.retries ?? 0) > 0);
     }
 
     return response;


### PR DESCRIPTION
### WHY are these changes introduced?

There was a small mistake in release v9.0.0 - the `request` method from the REST client was made `private` instead of `protected`, which was an incorrect change to the class' public API.

Also, a few `readonly` properties were removed from the client, which also had the same effect. They were added back.

### WHAT is this pull request doing?

Changing it back to `protected` so downstream code doesn't break.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
