### PR TITLE
Update ClientResponse.data type

### DIFF
--- a/.changeset/smooth-pears-boil.md
+++ b/.changeset/smooth-pears-boil.md
@@ -1,0 +1,7 @@
+---
+"@shopify/storefront-api-client": patch
+"@shopify/admin-api-client": patch
+"@shopify/graphql-client": patch
+---
+
+Remove `Partial` around the `ClientResponse.data` type for easier consumption of the client's returned typed data

--- a/packages/admin-api-client/README.md
+++ b/packages/admin-api-client/README.md
@@ -91,7 +91,7 @@ const {data, errors, extensions} = await client.request(operation, {
 
 | Name        | Type                      | Description                                                                                                                                                                                         |
 | ----------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data?       | `Partial<TData> \| any`            | Data returned from the Admin API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                                                  |
+| data?       | `TData \| any`            | Data returned from the Admin API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                                                  |
 | errors?     | [`ResponseErrors`](#responseerrors) | Error object that contains any API or network errors that occured while fetching the data from the API. It does not include any `UserErrors`.                                                       |
 | extensions? | `{[key: string]: any}`    | Additional information on the GraphQL response data and context. It can include the `context` object that contains the localization context information used to generate the returned API response. |
 

--- a/packages/graphql-client/README.md
+++ b/packages/graphql-client/README.md
@@ -75,7 +75,7 @@ const client = createGraphQLClient({
 
 | Name        | Type                  | Description                                                                                                                                                                                         |
 | ----------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data?       | `Partial<TData> \| any`        | Data returned from the GraphQL API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                                             |
+| data?       | `TData \| any`        | Data returned from the GraphQL API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                                             |
 | errors?      | [`ResponseErrors`](#responseerrors)       | Errors object that contains any API or network errors that occured while fetching the data from the API. It does not include any `UserErrors`.                                                       |
 | extensions? | `{[key: string]: any}` | Additional information on the GraphQL response data and context. It can include the `context` object that contains the context settings used to generate the returned API response. |
 

--- a/packages/graphql-client/src/graphql-client/types.ts
+++ b/packages/graphql-client/src/graphql-client/types.ts
@@ -21,7 +21,7 @@ export interface ResponseErrors {
 export type GQLExtensions = Record<string, any>;
 
 export interface FetchResponseBody<TData = any> {
-  data?: Partial<TData>;
+  data?: TData;
   extensions?: GQLExtensions;
 }
 

--- a/packages/storefront-api-client/README.md
+++ b/packages/storefront-api-client/README.md
@@ -87,7 +87,7 @@ const client = createStorefrontApiClient({
 
 | Name        | Type                  | Description                                                                                                                                                                                         |
 | ----------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| data?       | `Partial<TData> \| any`        | Data returned from the Storefront API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                                             |
+| data?       | `TData \| any`        | Data returned from the Storefront API. If `TData` was provided to the function, the return type is `TData`, else it returns type `any`.                                                             |
 | errors?      | [`ResponseErrors`](#responseerrors)       | Errors object that contains any API or network errors that occured while fetching the data from the API. It does not include any `UserErrors`.                                                       |
 | extensions? | `{[key: string]: any}` | Additional information on the GraphQL response data and context. It can include the `context` object that contains the context settings used to generate the returned API response. |
 


### PR DESCRIPTION
### WHY are these changes introduced?
Currently, the `ClientResponse.data` has a `Partial<TData>` type to account for scenarios when the Graph API responds with only partial data (eg. when the used access token does not have the correct access scope and permissions for certain fields within the query). However, we've received [feedback](https://github.com/Shopify/shopify-api-js/commit/194ddcf27a89edb46ad7ee348b6e8a9e65d332ff#r137199135) from the community saying that by typing `ClientResponse.data` this way, it made it more cumbersome to use the client's return because client users will need to either consistently null check the data object or typecast the response.

We've decided to update `ClientResponse.data` to the full `TData` for easier consumption of the response data object. However we acknowledge that by do so, this does create the rare occasion where the client response is incorrectly typed when the GraphQL API server responds with partial data but we feel the ergonomic gains is worth this risk.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
