### PR TITLE
Add ignore-engines flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.version }}
+      # TODO Remove the --ignore-engines flag when we drop support for Node 16
       - name: Install
-        run: yarn install
+        run: yarn install --ignore-engines
       - name: Build
         run: yarn build
       - name: Lint


### PR DESCRIPTION
* Node 16 is eol, but we will continue to support it because many developers are still using it
* This will allow the pipeline to pass, even though some dependencies don't support Node 16

[Example PR](https://github.com/Shopify/shopify-api-js/pull/1142)

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
