### PR TITLE
[Chore] Ignore node engines in release workflows

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -21,8 +21,9 @@ jobs:
           node-version: 16.x
           cache: 'yarn'
 
+      # TODO Remove the --ignore-engines flag when we drop support for Node 16
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --frozen-lockfile --ignore-engines
 
       - name: Create release Pull Request or publish to NPM
         id: changesets

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -21,8 +21,9 @@ jobs:
           node-version: 16.x
           cache: 'yarn'
 
+      # TODO Remove the --ignore-engines flag when we drop support for Node 16
       - name: Install dependencies
-        run: yarn --frozen-lockfile
+        run: yarn --frozen-lockfile --ignore-engines
 
       - name: Create release candidate PR or publish to NPM
         id: changesets


### PR DESCRIPTION
This PR just adds the `--ignore-engines` flag to the release workflows that also need to install node.