### PR TITLE
Update line item billing flag to v10

### DIFF
--- a/.changeset/gorgeous-kids-crash.md
+++ b/.changeset/gorgeous-kids-crash.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": minor
+---
+
+Update lineItemBilling future flag to v10

--- a/packages/shopify-api/docs/guides/billing.md
+++ b/packages/shopify-api/docs/guides/billing.md
@@ -9,7 +9,7 @@ To trigger the billing behaviour, you'll need to set the `billing` value when ca
 
 ## Configuring LineItem billing
 
-With the future flag `unstable_lineItemBilling`, the billing configuration can now specify the the `AppSubscriptionLineItems`. This will allow you to create app subscription plans with both recurring and usage based charges.
+With the future flag `v10_lineItemBilling`, the billing configuration can now specify the the `AppSubscriptionLineItems`. This will allow you to create app subscription plans with both recurring and usage based charges.
 
 Subscription plans can have 1 or 2 line items. There can be a maximum of 1 of each type of plan Usage and Recurring. Usage line items can only be used in conjunction with recurring line items when the recurring line item interval is `BillingInterval.Every30Days`.
 
@@ -47,7 +47,7 @@ const shopify = shopifyApi({
   },
 }
 future: {
-  unstable_lineItemBilling: true,
+  v10_lineItemBilling: true,
 });
 ```
 
@@ -89,7 +89,7 @@ const shopify = shopifyApi({
   },
 },
 future: {
-  unstable_lineItemBilling: true,
+  v10_lineItemBilling: true,
 });
 ```
 
@@ -113,7 +113,7 @@ const shopify = shopifyApi({
   },
 }
 future: {
-  unstable_lineItemBilling: true,
+  v10_lineItemBilling: true,
 });
 ```
 
@@ -158,7 +158,7 @@ future: {
 
 ## Configuring Billing
 
-Prior to the future flag `unstable_lineItemBilling` and when the flag is set to false you will configure billing as follows. For example, the following configuration will allow you to charge merchants $30 every 30 days. The first three charges will be discounted by $10, so merchants would be charged $20.
+Prior to the future flag `v10_lineItemBilling` and when the flag is set to false you will configure billing as follows. For example, the following configuration will allow you to charge merchants $30 every 30 days. The first three charges will be discounted by $10, so merchants would be charged $20.
 
 ```ts
 import {

--- a/packages/shopify-api/future/flags.ts
+++ b/packages/shopify-api/future/flags.ts
@@ -9,7 +9,7 @@ export interface FutureFlags {
   /**
    * Enable line item billing, to make billing configuration more similar to the GraphQL API.
    */
-  unstable_lineItemBilling?: boolean;
+  v10_lineItemBilling?: boolean;
 }
 
 /**

--- a/packages/shopify-api/lib/__tests__/test-config.ts
+++ b/packages/shopify-api/lib/__tests__/test-config.ts
@@ -53,7 +53,7 @@ type TestConfig<Overrides extends TestOverridesOption<Future>, Future> = Modify<
  * old behaviour.
  */
 const TEST_FUTURE_FLAGS: Required<{[key in keyof FutureFlags]: true}> = {
-  unstable_lineItemBilling: true,
+  v10_lineItemBilling: true,
   unstable_tokenExchange: true,
 } as const;
 

--- a/packages/shopify-api/lib/billing/__tests__/legacy-request.test.ts
+++ b/packages/shopify-api/lib/billing/__tests__/legacy-request.test.ts
@@ -23,9 +23,7 @@ const GRAPHQL_BASE_REQUEST = {
 
 interface TestConfigInterface {
   name: string;
-  billingConfig:
-    | BillingConfig
-    | BillingConfig<{unstable_lineItemBilling: false}>;
+  billingConfig: BillingConfig | BillingConfig<{v10_lineItemBilling: false}>;
   paymentResponse: string;
   responseObject: any;
   errorResponse: string;
@@ -197,7 +195,7 @@ describe('shopify.billing.request', () => {
         testConfig({
           billing: undefined,
           future: {
-            unstable_lineItemBilling: false,
+            v10_lineItemBilling: false,
           },
         }),
       );
@@ -224,7 +222,7 @@ describe('shopify.billing.request', () => {
                 testConfig({
                   billing: config.billingConfig,
                   future: {
-                    unstable_lineItemBilling: false,
+                    v10_lineItemBilling: false,
                   },
                 }),
               );
@@ -261,7 +259,7 @@ describe('shopify.billing.request', () => {
               testConfig({
                 billing: config.billingConfig,
                 future: {
-                  unstable_lineItemBilling: false,
+                  v10_lineItemBilling: false,
                 },
               }),
             );
@@ -298,7 +296,7 @@ describe('shopify.billing.request', () => {
               testConfig({
                 billing: config.billingConfig,
                 future: {
-                  unstable_lineItemBilling: false,
+                  v10_lineItemBilling: false,
                 },
               }),
             );
@@ -330,7 +328,7 @@ describe('shopify.billing.request', () => {
               testConfig({
                 billing: config.billingConfig,
                 future: {
-                  unstable_lineItemBilling: false,
+                  v10_lineItemBilling: false,
                 },
               }),
             );
@@ -388,7 +386,7 @@ describe('shopify.billing.request', () => {
               testConfig({
                 billing: config.billingConfig,
                 future: {
-                  unstable_lineItemBilling: false,
+                  v10_lineItemBilling: false,
                 },
               }),
             );
@@ -419,7 +417,7 @@ describe('shopify.billing.request', () => {
               testConfig({
                 billing: config.billingConfig,
                 future: {
-                  unstable_lineItemBilling: false,
+                  v10_lineItemBilling: false,
                 },
               }),
             );
@@ -499,7 +497,7 @@ describe('shopify.billing.request', () => {
             },
           },
           future: {
-            unstable_lineItemBilling: false,
+            v10_lineItemBilling: false,
           },
         }),
       );
@@ -532,7 +530,7 @@ describe('shopify.billing.request', () => {
             },
           },
           future: {
-            unstable_lineItemBilling: false,
+            v10_lineItemBilling: false,
           },
         }),
       );
@@ -570,7 +568,7 @@ describe('shopify.billing.request', () => {
             },
           },
           future: {
-            unstable_lineItemBilling: false,
+            v10_lineItemBilling: false,
           },
         }),
       );

--- a/packages/shopify-api/lib/billing/__tests__/request.test.ts
+++ b/packages/shopify-api/lib/billing/__tests__/request.test.ts
@@ -23,7 +23,7 @@ const GRAPHQL_BASE_REQUEST = {
 
 interface TestConfigInterface {
   name: string;
-  billingConfig: BillingConfig<{unstable_lineItemBilling: true}>;
+  billingConfig: BillingConfig<{v10_lineItemBilling: true}>;
   paymentResponse: string;
   responseObject: any;
   errorResponse: string;

--- a/packages/shopify-api/lib/billing/types.ts
+++ b/packages/shopify-api/lib/billing/types.ts
@@ -118,7 +118,7 @@ export type BillingConfigLegacyItem =
 
 export type BillingConfigItem<
   Future extends FutureFlagOptions = FutureFlagOptions,
-> = FeatureEnabled<Future, 'unstable_lineItemBilling'> extends true
+> = FeatureEnabled<Future, 'v10_lineItemBilling'> extends true
   ? BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan
   : BillingConfigLegacyItem;
 


### PR DESCRIPTION
### WHY are these changes introduced?
* We will release line item billing fully in version 10.0.0
* Anyone currently using the unstable flag will need to now use `v10_lineItemBilling`

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
