### PR TITLE
[GraphQL Client] Add default SDK headers to graphql-client

### DIFF
--- a/.changeset/funny-doors-switch.md
+++ b/.changeset/funny-doors-switch.md
@@ -1,0 +1,5 @@
+---
+"@shopify/graphql-client": patch
+---
+
+Add default SDK headers to all API requests when none are provided

--- a/packages/graphql-client/src/graphql-client/constants.ts
+++ b/packages/graphql-client/src/graphql-client/constants.ts
@@ -13,6 +13,12 @@ export const CONTENT_TYPES = {
   json: "application/json",
   multipart: "multipart/mixed",
 };
+export const SDK_VARIANT_HEADER = "X-SDK-Variant";
+export const SDK_VERSION_HEADER = "X-SDK-Version";
+
+export const DEFAULT_SDK_VARIANT = "shopify-graphql-client";
+// This is value is replaced with package.json version during rollup build process
+export const DEFAULT_CLIENT_VERSION = "ROLLUP_REPLACE_CLIENT_VERSION";
 
 export const RETRY_WAIT_TIME = 1000;
 export const RETRIABLE_STATUS_CODES = [429, 503];

--- a/packages/graphql-client/src/graphql-client/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client/graphql-client.ts
@@ -19,6 +19,10 @@ import {
   HEADER_SEPARATOR,
   DEFER_OPERATION_REGEX,
   BOUNDARY_HEADER_REGEX,
+  SDK_VARIANT_HEADER,
+  SDK_VERSION_HEADER,
+  DEFAULT_SDK_VARIANT,
+  DEFAULT_CLIENT_VERSION,
 } from "./constants";
 import {
   formatErrorMessage,
@@ -121,6 +125,11 @@ function generateFetch(
       headers[key] = Array.isArray(value) ? value.join(", ") : value.toString();
       return headers;
     }, {});
+
+    if (!flatHeaders[SDK_VARIANT_HEADER] && !flatHeaders[SDK_VERSION_HEADER]) {
+      flatHeaders[SDK_VARIANT_HEADER] = DEFAULT_SDK_VARIANT;
+      flatHeaders[SDK_VERSION_HEADER] = DEFAULT_CLIENT_VERSION;
+    }
 
     const fetchParams: Parameters<CustomFetchApi> = [
       overrideUrl ?? url,

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/client-fetch-request.test.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/client-fetch-request.test.ts
@@ -1,14 +1,14 @@
 import fetchMock from "jest-fetch-mock";
 
 import { GraphQLClient } from "../../types";
-import {
-  SDK_VARIANT_HEADER,
-  SDK_VERSION_HEADER,
-  DEFAULT_CLIENT_VERSION,
-  DEFAULT_SDK_VARIANT,
-} from "../../constants";
 
-import { operation, variables, clientConfig, getValidClient } from "./fixtures";
+import {
+  operation,
+  variables,
+  clientConfig,
+  getValidClient,
+  defaultHeaders,
+} from "./fixtures";
 import {
   fetchApiTests,
   parametersTests,
@@ -136,11 +136,7 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: {
-                  ...clientConfig.headers,
-                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                },
+                headers: defaultHeaders,
               },
             ];
 
@@ -266,11 +262,7 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: {
-                  ...clientConfig.headers,
-                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                },
+                headers: defaultHeaders,
               },
             ];
 
@@ -335,11 +327,7 @@ describe("GraphQL Client", () => {
                 {
                   method: "POST",
                   body: JSON.stringify({ query: operation }),
-                  headers: {
-                    ...clientConfig.headers,
-                    [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                    [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                  },
+                  headers: defaultHeaders,
                 },
               ],
             },
@@ -657,11 +645,7 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: {
-                  ...clientConfig.headers,
-                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                },
+                headers: defaultHeaders,
               },
             ];
 
@@ -802,11 +786,7 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: {
-                  ...clientConfig.headers,
-                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                },
+                headers: defaultHeaders,
               },
             ];
 
@@ -872,11 +852,7 @@ describe("GraphQL Client", () => {
                 {
                   method: "POST",
                   body: JSON.stringify({ query: operation }),
-                  headers: {
-                    ...clientConfig.headers,
-                    [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                    [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                  },
+                  headers: defaultHeaders,
                 },
               ],
             },

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/client-fetch-request.test.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/client-fetch-request.test.ts
@@ -1,9 +1,20 @@
 import fetchMock from "jest-fetch-mock";
 
 import { GraphQLClient } from "../../types";
+import {
+  SDK_VARIANT_HEADER,
+  SDK_VERSION_HEADER,
+  DEFAULT_CLIENT_VERSION,
+  DEFAULT_SDK_VARIANT,
+} from "../../constants";
 
 import { operation, variables, clientConfig, getValidClient } from "./fixtures";
-import { fetchApiTests, parametersTests, retryTests } from "./common-tests";
+import {
+  fetchApiTests,
+  parametersTests,
+  sdkHeadersTests,
+  retryTests,
+} from "./common-tests";
 
 describe("GraphQL Client", () => {
   let mockLogger: jest.Mock;
@@ -33,6 +44,10 @@ describe("GraphQL Client", () => {
     describe("calling the function", () => {
       describe("function parameters", () => {
         parametersTests(functionName);
+      });
+
+      describe("SDK headers", () => {
+        sdkHeadersTests(functionName);
       });
 
       describe("returned object", () => {
@@ -121,7 +136,11 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: clientConfig.headers,
+                headers: {
+                  ...clientConfig.headers,
+                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                },
               },
             ];
 
@@ -247,7 +266,11 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: clientConfig.headers,
+                headers: {
+                  ...clientConfig.headers,
+                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                },
               },
             ];
 
@@ -312,7 +335,11 @@ describe("GraphQL Client", () => {
                 {
                   method: "POST",
                   body: JSON.stringify({ query: operation }),
-                  headers: clientConfig.headers,
+                  headers: {
+                    ...clientConfig.headers,
+                    [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                    [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                  },
                 },
               ],
             },
@@ -326,6 +353,10 @@ describe("GraphQL Client", () => {
     const functionName = "request";
 
     fetchApiTests(functionName);
+
+    describe("SDK headers", () => {
+      sdkHeadersTests(functionName);
+    });
 
     describe("calling the function", () => {
       describe("function parameters", () => {
@@ -626,7 +657,11 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: clientConfig.headers,
+                headers: {
+                  ...clientConfig.headers,
+                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                },
               },
             ];
 
@@ -767,7 +802,11 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: clientConfig.headers,
+                headers: {
+                  ...clientConfig.headers,
+                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                },
               },
             ];
 
@@ -833,7 +872,11 @@ describe("GraphQL Client", () => {
                 {
                   method: "POST",
                   body: JSON.stringify({ query: operation }),
-                  headers: clientConfig.headers,
+                  headers: {
+                    ...clientConfig.headers,
+                    [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                    [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                  },
                 },
               ],
             },

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/client-requestStream.test.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/client-requestStream.test.ts
@@ -1,6 +1,12 @@
 import fetchMock from "jest-fetch-mock";
 
 import { GraphQLClient, ClientStreamResponse } from "../../types";
+import {
+  SDK_VARIANT_HEADER,
+  SDK_VERSION_HEADER,
+  DEFAULT_CLIENT_VERSION,
+  DEFAULT_SDK_VARIANT,
+} from "../../constants";
 
 import {
   clientConfig,
@@ -9,7 +15,12 @@ import {
   createIterableBufferResponse,
   createReaderStreamResponse,
 } from "./fixtures";
-import { fetchApiTests, parametersTests, retryTests } from "./common-tests";
+import {
+  fetchApiTests,
+  parametersTests,
+  sdkHeadersTests,
+  retryTests,
+} from "./common-tests";
 
 const operation = `
 query shop($country: CountryCode, $language: LanguageCode) @inContext(country: $country, language: $language) {
@@ -56,6 +67,10 @@ describe("GraphQL Client", () => {
     const description = "Test shop description";
 
     fetchApiTests(functionName, operation);
+
+    describe("SDK headers", () => {
+      sdkHeadersTests(functionName, operation);
+    });
 
     describe("calling the function", () => {
       describe("fetch parameters", () => {
@@ -1171,7 +1186,11 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: clientConfig.headers,
+                headers: {
+                  ...clientConfig.headers,
+                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                },
               },
             ];
 
@@ -1333,7 +1352,11 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: clientConfig.headers,
+                headers: {
+                  ...clientConfig.headers,
+                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                },
               },
             ];
 
@@ -1407,7 +1430,11 @@ describe("GraphQL Client", () => {
                 {
                   method: "POST",
                   body: JSON.stringify({ query: operation }),
-                  headers: clientConfig.headers,
+                  headers: {
+                    ...clientConfig.headers,
+                    [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+                    [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
+                  },
                 },
               ],
             },

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/client-requestStream.test.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/client-requestStream.test.ts
@@ -1,12 +1,6 @@
 import fetchMock from "jest-fetch-mock";
 
 import { GraphQLClient, ClientStreamResponse } from "../../types";
-import {
-  SDK_VARIANT_HEADER,
-  SDK_VERSION_HEADER,
-  DEFAULT_CLIENT_VERSION,
-  DEFAULT_SDK_VARIANT,
-} from "../../constants";
 
 import {
   clientConfig,
@@ -14,6 +8,7 @@ import {
   createIterableResponse,
   createIterableBufferResponse,
   createReaderStreamResponse,
+  defaultHeaders,
 } from "./fixtures";
 import {
   fetchApiTests,
@@ -1186,11 +1181,7 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: {
-                  ...clientConfig.headers,
-                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                },
+                headers: defaultHeaders,
               },
             ];
 
@@ -1352,11 +1343,7 @@ describe("GraphQL Client", () => {
               {
                 method: "POST",
                 body: JSON.stringify({ query: operation }),
-                headers: {
-                  ...clientConfig.headers,
-                  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                },
+                headers: defaultHeaders,
               },
             ];
 
@@ -1430,11 +1417,7 @@ describe("GraphQL Client", () => {
                 {
                   method: "POST",
                   body: JSON.stringify({ query: operation }),
-                  headers: {
-                    ...clientConfig.headers,
-                    [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-                    [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-                  },
+                  headers: defaultHeaders,
                 },
               ],
             },

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/common-tests.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/common-tests.ts
@@ -9,15 +9,15 @@ import {
   DEFAULT_SDK_VARIANT,
 } from "../../constants";
 
-import { operation, variables, clientConfig, getValidClient } from "./fixtures";
+import {
+  operation,
+  variables,
+  clientConfig,
+  getValidClient,
+  defaultHeaders,
+} from "./fixtures";
 
 type ClientFunctionNames = keyof Omit<GraphQLClient, "config">;
-
-const defaultHeaders = {
-  ...clientConfig.headers,
-  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
-  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
-};
 
 export const fetchApiTests = (
   functionName: ClientFunctionNames,
@@ -238,6 +238,34 @@ export const sdkHeadersTests = (
         [SDK_VARIANT_HEADER]: "custom-client",
         [SDK_VERSION_HEADER]: "0.0.1",
       };
+
+      await client[functionName](gqlOperation, { headers: customHeaders });
+      expect(fetchMock).toHaveBeenCalledWith(clientConfig.url, {
+        method: "POST",
+        headers: {
+          ...clientConfig.headers,
+          ...customHeaders,
+        },
+        body: JSON.stringify({
+          query: gqlOperation,
+        }),
+      });
+    });
+
+    it("includes the function parameter custom SDK variant and version headers if both function parameter and client init config includes SDK headers", async () => {
+      const initCustomHeaders = {
+        [SDK_VARIANT_HEADER]: "custom-client",
+        [SDK_VERSION_HEADER]: "0.0.1",
+      };
+
+      const customHeaders = {
+        [SDK_VARIANT_HEADER]: "custom-client-1",
+        [SDK_VERSION_HEADER]: "0.0.2",
+      };
+
+      client = getValidClient({
+        headers: initCustomHeaders,
+      });
 
       await client[functionName](gqlOperation, { headers: customHeaders });
       expect(fetchMock).toHaveBeenCalledWith(clientConfig.url, {

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/fixtures.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/fixtures.ts
@@ -9,6 +9,12 @@ import {
   ClientOptions,
   Headers as TypesHeaders,
 } from "../../types";
+import {
+  SDK_VARIANT_HEADER,
+  SDK_VERSION_HEADER,
+  DEFAULT_CLIENT_VERSION,
+  DEFAULT_SDK_VARIANT,
+} from "../../constants";
 
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as any;
@@ -31,6 +37,12 @@ query {
 
 export const variables = {
   country: "US",
+};
+
+export const defaultHeaders = {
+  ...clientConfig.headers,
+  [SDK_VARIANT_HEADER]: DEFAULT_SDK_VARIANT,
+  [SDK_VERSION_HEADER]: DEFAULT_CLIENT_VERSION,
 };
 
 export function getValidClient({

--- a/packages/graphql-client/src/graphql-client/tests/graphql-client/fixtures.ts
+++ b/packages/graphql-client/src/graphql-client/tests/graphql-client/fixtures.ts
@@ -4,7 +4,11 @@ import { Readable } from "stream";
 import { ReadableStream } from "web-streams-polyfill/es2018";
 
 import { createGraphQLClient } from "../../graphql-client";
-import { LogContentTypes, ClientOptions } from "../../types";
+import {
+  LogContentTypes,
+  ClientOptions,
+  Headers as TypesHeaders,
+} from "../../types";
 
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder as any;
@@ -32,9 +36,11 @@ export const variables = {
 export function getValidClient({
   retries,
   logger,
+  headers,
 }: {
   retries?: number;
   logger?: (logContent: LogContentTypes) => void;
+  headers?: TypesHeaders;
 } = {}) {
   const updatedConfig: ClientOptions = { ...clientConfig };
 
@@ -44,6 +50,13 @@ export function getValidClient({
 
   if (logger !== undefined) {
     updatedConfig.logger = logger;
+  }
+
+  if (headers !== undefined) {
+    updatedConfig.headers = {
+      ...updatedConfig.headers,
+      ...headers,
+    };
   }
 
   return createGraphQLClient(updatedConfig);


### PR DESCRIPTION
### WHY are these changes introduced?
Add default standard SDK variant and version headers to API requests if they were not provided during the `graphql-client` initialization or given as a custom header at function call.  The default SDK headers are only added if neither the variant and version headers were provided.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
