### PR TITLE
[Fix][GraphQL client] Remove buffer check from `requestStream()`

### DIFF
--- a/.changeset/eleven-jars-kick.md
+++ b/.changeset/eleven-jars-kick.md
@@ -2,4 +2,4 @@
 "@shopify/graphql-client": patch
 ---
 
-Update `requestStream()` to check if `Buffer` exists before using Buffer check utility
+Update `requestStream()` to always process response iterator chunks as `Uint8Array` values

--- a/.changeset/eleven-jars-kick.md
+++ b/.changeset/eleven-jars-kick.md
@@ -1,0 +1,5 @@
+---
+"@shopify/graphql-client": patch
+---
+
+Update `requestStream()` to check if `Buffer` exists before using Buffer check utility

--- a/packages/graphql-client/src/graphql-client/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client/graphql-client.ts
@@ -193,11 +193,7 @@ async function* getStreamBodyIterator(
   // Response body is an async iterator
   if ((response.body as any)![Symbol.asyncIterator]) {
     for await (const chunk of response.body! as any) {
-      if (typeof Buffer !== "undefined" && Buffer.isBuffer(chunk)) {
-        yield (chunk as Buffer).toString();
-      } else {
-        yield decoder.decode(chunk);
-      }
+      yield decoder.decode(chunk);
     }
   } else {
     const reader = response.body!.getReader();

--- a/packages/graphql-client/src/graphql-client/graphql-client.ts
+++ b/packages/graphql-client/src/graphql-client/graphql-client.ts
@@ -190,10 +190,10 @@ async function* getStreamBodyIterator(
 ): AsyncIterableIterator<string> {
   const decoder = new TextDecoder();
 
-  // Support node format
+  // Response body is an async iterator
   if ((response.body as any)![Symbol.asyncIterator]) {
     for await (const chunk of response.body! as any) {
-      if (Buffer.isBuffer(chunk)) {
+      if (typeof Buffer !== "undefined" && Buffer.isBuffer(chunk)) {
         yield (chunk as Buffer).toString();
       } else {
         yield decoder.decode(chunk);


### PR DESCRIPTION
### WHY are these changes introduced?
In the `graphql-client.requestStream()` implementation, we use the `Buffer.isBuffer()` to check whether the streamed chunk is a `Buffer` instance, however since `Buffer` is an instance of `Uint8Array`, we can process the chunk as a standard `Uint8Array` and use `TextDecoder` to convert the encoded array values to string. 

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
