### PR TITLE
Replace graphql-codegen package

### DIFF
--- a/.changeset/sixty-rocks-teach.md
+++ b/.changeset/sixty-rocks-teach.md
@@ -1,0 +1,5 @@
+---
+"@shopify/api-codegen-preset": patch
+---
+
+Replaced @shopify/hydrogen-codegen with its more generic successor, @shopify/graphql-codegen. All of the changes are internal, so this package is unchanged.

--- a/packages/api-codegen-preset/package.json
+++ b/packages/api-codegen-preset/package.json
@@ -71,7 +71,7 @@
     "@graphql-codegen/introspection": "^4.0.0",
     "@graphql-codegen/typescript": "^4.0.4",
     "@parcel/watcher": "^2.4.0",
-    "@shopify/hydrogen-codegen": "^0.2.1",
+    "@shopify/graphql-codegen": "^0.0.1",
     "graphql": "^16.8.1"
   },
   "devDependencies": {

--- a/packages/api-codegen-preset/src/api-project.ts
+++ b/packages/api-codegen-preset/src/api-project.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 
-import { pluckConfig } from "@shopify/hydrogen-codegen";
+import { pluckConfig } from "@shopify/graphql-codegen";
 
 import type { ShopifyApiProjectOptions } from "./types";
 import { shopifyApiTypes } from "./api-types";

--- a/packages/api-codegen-preset/src/helpers/api-configs.ts
+++ b/packages/api-codegen-preset/src/helpers/api-configs.ts
@@ -8,8 +8,10 @@ interface ApiConfig {
   interfaceExtension: string;
   module: string;
   presetConfigs: {
-    importTypesFrom: string;
-    namespacedImportName: string;
+    importTypes: {
+      namespace: string;
+      from: string;
+    };
   };
 }
 
@@ -26,8 +28,10 @@ export const apiConfigs: ApiConfigs = {
     interfaceExtension: `declare module '%%MODULE%%' {\n  type InputMaybe<T> = AdminTypes.InputMaybe<T>;\n  interface AdminQueries extends %%QUERY%% {}\n  interface AdminMutations extends %%MUTATION%% {}\n}`,
     module: "@shopify/admin-api-client",
     presetConfigs: {
-      importTypesFrom: "./admin.types.d.ts",
-      namespacedImportName: "AdminTypes",
+      importTypes: {
+        namespace: "AdminTypes",
+        from: "./admin.types.d.ts",
+      },
     },
   },
   Storefront: {
@@ -39,8 +43,10 @@ export const apiConfigs: ApiConfigs = {
     interfaceExtension: `declare module '%%MODULE%%' {\n  type InputMaybe<T> = StorefrontTypes.InputMaybe<T>;\n  interface StorefrontQueries extends %%QUERY%% {}\n  interface StorefrontMutations extends %%MUTATION%% {}\n}`,
     module: "@shopify/storefront-api-client",
     presetConfigs: {
-      importTypesFrom: "./storefront.types.d.ts",
-      namespacedImportName: "StorefrontTypes",
+      importTypes: {
+        namespace: "StorefrontTypes",
+        from: "./storefront.types.d.ts",
+      },
     },
   },
 };

--- a/packages/api-codegen-preset/src/index.ts
+++ b/packages/api-codegen-preset/src/index.ts
@@ -2,4 +2,4 @@ export * from "./types";
 export * from "./preset";
 export * from "./api-types";
 export * from "./api-project";
-export { pluckConfig } from "@shopify/hydrogen-codegen";
+export { pluckConfig } from "@shopify/graphql-codegen";

--- a/packages/api-codegen-preset/src/preset.ts
+++ b/packages/api-codegen-preset/src/preset.ts
@@ -1,5 +1,5 @@
 import type { Types } from "@graphql-codegen/plugin-helpers";
-import { preset as hydrogenPreset } from "@shopify/hydrogen-codegen";
+import { preset as hydrogenPreset } from "@shopify/graphql-codegen";
 
 import { type ShopifyApiPresetConfig } from "./types";
 import { apiConfigs } from "./helpers/api-configs";

--- a/packages/api-codegen-preset/src/tests/preset.test.ts
+++ b/packages/api-codegen-preset/src/tests/preset.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 import { executeCodegen } from "@graphql-codegen/cli";
-import { pluckConfig } from "@shopify/hydrogen-codegen";
+import { pluckConfig } from "@shopify/graphql-codegen";
 
 import { ApiType, preset } from "..";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,10 +2890,10 @@
     pkg-dir "^5.0.0"
     pluralize "^8.0.0"
 
-"@shopify/hydrogen-codegen@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@shopify/hydrogen-codegen/-/hydrogen-codegen-0.2.1.tgz#24ae0ddd3e051005b4d8b07a793060096a018062"
-  integrity sha512-Ozb1YT37XutNdmdigJaKLgon0q2kAzdzT0hQR6A9ea71P4/oeRaMKhRe5f05XHLktUAVmdghVSDry+bU9bEXqQ==
+"@shopify/graphql-codegen@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@shopify/graphql-codegen/-/graphql-codegen-0.0.1.tgz#5d1633d148db7fb091b51af50087b55cca8a6ff1"
+  integrity sha512-A6LwdihfS0DzfiwwFcSC4CSG5laTwEyVySqYlf1uvo2G9fuxb79FjhmO6WY0kP3P1/Ktg/w3H1w6muzOv2n3qA==
   dependencies:
     "@graphql-codegen/add" "^5.0.1"
     "@graphql-codegen/typescript" "^4.0.2"
@@ -9358,9 +9358,9 @@ type-fest@^0.8.1:
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
 type-fest@^4.5.0:
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.10.2.tgz#3abdb144d93c5750432aac0d73d3e85fcab45738"
-  integrity sha512-anpAG63wSpdEbLwOqH8L84urkL6PiVIov3EMmgIhhThevh9aiMQov+6Btx0wldNcvm4wV+e2/Rt1QdDwKHFbHw==
+  version "4.10.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.10.3.tgz#ff01cb0a1209f59583d61e1312de9715e7ea4874"
+  integrity sha512-JLXyjizi072smKGGcZiAJDCNweT8J+AuRxmPZ1aG7TERg4ijx9REl8CNhbr36RV4qXqL1gO1FF9HL8OkVmmrsA==
 
 type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
### WHY are these changes introduced?

The `@shopify/hydrogen-codegen` package was deprecated in favour of `@shopify/graphql-codegen`, which is essentially the same for now, save some changed configs.

### WHAT is this pull request doing?

Replacing the package and updating the configs so we can continue to get improvements.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
