### PR TITLE
Refactor the validation of HMAC to be more reusable

### DIFF
--- a/.changeset/grumpy-numbers-count.md
+++ b/.changeset/grumpy-numbers-count.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Refactor HMAC validation to use a common function.

--- a/packages/shopify-api/lib/flow/types.ts
+++ b/packages/shopify-api/lib/flow/types.ts
@@ -1,3 +1,8 @@
+import {
+  ValidationErrorReason,
+  ValidationInvalid,
+  ValidationValid,
+} from '../utils/types';
 import {AdapterArgs} from '../../runtime/types';
 
 export interface FlowValidateParams extends AdapterArgs {
@@ -7,26 +12,19 @@ export interface FlowValidateParams extends AdapterArgs {
   rawBody: string;
 }
 
-export enum FlowValidationErrorReason {
-  MissingBody = 'missing_body',
-  MissingHmac = 'missing_hmac',
-  InvalidHmac = 'invalid_hmac',
-}
+export const FlowValidationErrorReason = {
+  ...ValidationErrorReason,
+} as const;
 
-export interface FlowValidationInvalid {
-  /**
-   * Whether the request is a valid Flow request from Shopify.
-   */
-  valid: false;
+export type FlowValidationErrorReasonType =
+  (typeof FlowValidationErrorReason)[keyof typeof FlowValidationErrorReason];
+
+export interface FlowValidationInvalid
+  extends Omit<ValidationInvalid, 'reason'> {
   /**
    * The reason why the request is not valid.
    */
-  reason: FlowValidationErrorReason;
+  reason: FlowValidationErrorReasonType;
 }
 
-export interface FlowValidationValid {
-  /**
-   * Whether the request is a valid Flow request from Shopify.
-   */
-  valid: true;
-}
+export interface FlowValidationValid extends ValidationValid {}

--- a/packages/shopify-api/lib/flow/validate.ts
+++ b/packages/shopify-api/lib/flow/validate.ts
@@ -1,60 +1,22 @@
-import {abstractConvertRequest, getHeader} from '../../runtime/http';
-import {HashFormat} from '../../runtime/crypto/types';
-import {ConfigInterface} from '../base-types';
-import {logger} from '../logger';
-import {ShopifyHeader} from '../types';
-import {validateHmacString} from '../utils/hmac-validator';
-
 import {
-  FlowValidateParams,
-  FlowValidationInvalid,
-  FlowValidationValid,
-  FlowValidationErrorReason,
-} from './types';
+  HmacValidationType,
+  ValidationInvalid,
+  ValidationValid,
+} from '../utils/types';
+import {validateHmacFromRequestFactory} from '../utils/hmac-validator';
+import {ConfigInterface} from '../base-types';
+
+import {FlowValidateParams} from './types';
 
 export function validateFactory(config: ConfigInterface) {
   return async function validate({
     rawBody,
     ...adapterArgs
-  }: FlowValidateParams): Promise<FlowValidationInvalid | FlowValidationValid> {
-    const request = await abstractConvertRequest(adapterArgs);
-
-    if (!rawBody.length) {
-      return fail(FlowValidationErrorReason.MissingBody, config);
-    }
-
-    const hmac = getHeader(request.headers, ShopifyHeader.Hmac);
-
-    if (!hmac) {
-      return fail(FlowValidationErrorReason.MissingHmac, config);
-    }
-
-    if (await validateHmacString(config, rawBody, hmac, HashFormat.Base64)) {
-      return succeed(config);
-    }
-
-    return fail(FlowValidationErrorReason.InvalidHmac, config);
-  };
-}
-
-async function fail(
-  reason: FlowValidationErrorReason,
-  config: ConfigInterface,
-): Promise<FlowValidationInvalid> {
-  const log = logger(config);
-  await log.debug('Flow request is not valid', {reason});
-
-  return {
-    valid: false,
-    reason,
-  };
-}
-
-async function succeed(config: ConfigInterface): Promise<FlowValidationValid> {
-  const log = logger(config);
-  await log.debug('Flow request is valid');
-
-  return {
-    valid: true,
+  }: FlowValidateParams): Promise<ValidationInvalid | ValidationValid> {
+    return validateHmacFromRequestFactory(config)({
+      type: HmacValidationType.Flow,
+      rawBody,
+      ...adapterArgs,
+    });
   };
 }

--- a/packages/shopify-api/lib/utils/types.ts
+++ b/packages/shopify-api/lib/utils/types.ts
@@ -1,0 +1,36 @@
+export enum HmacValidationType {
+  Flow = 'flow',
+  Webhook = 'webhook',
+}
+
+export enum ValidationType {
+  Flow = 'flow',
+  Webhook = 'webhook',
+}
+
+export const ValidationErrorReason = {
+  MissingBody: 'missing_body',
+  InvalidHmac: 'invalid_hmac',
+  MissingHmac: 'missing_hmac',
+} as const;
+
+export type ValidationErrorReasonType =
+  (typeof ValidationErrorReason)[keyof typeof ValidationErrorReason];
+
+export interface ValidationInvalid {
+  /**
+   * Whether the request is a valid Flow request from Shopify.
+   */
+  valid: false;
+  /**
+   * The reason why the request is not valid.
+   */
+  reason: ValidationErrorReasonType;
+}
+
+export interface ValidationValid {
+  /**
+   * Whether the request is a valid request from Shopify.
+   */
+  valid: true;
+}

--- a/packages/shopify-api/lib/utils/types.ts
+++ b/packages/shopify-api/lib/utils/types.ts
@@ -3,11 +3,6 @@ export enum HmacValidationType {
   Webhook = 'webhook',
 }
 
-export enum ValidationType {
-  Flow = 'flow',
-  Webhook = 'webhook',
-}
-
 export const ValidationErrorReason = {
   MissingBody: 'missing_body',
   InvalidHmac: 'invalid_hmac',

--- a/packages/shopify-api/lib/webhooks/__tests__/process.test.ts
+++ b/packages/shopify-api/lib/webhooks/__tests__/process.test.ts
@@ -248,7 +248,12 @@ describe('shopify.webhooks.process', () => {
     for (const header of emptyHeaders) {
       const response = await request(app)
         .post('/webhooks')
-        .set(headers(header))
+        .set(
+          headers({
+            hmac: hmac(shopify.config.apiSecretKey, rawBody),
+            ...header,
+          }),
+        )
         .send(rawBody)
         .expect(StatusCode.BadRequest);
 

--- a/packages/shopify-api/lib/webhooks/types.ts
+++ b/packages/shopify-api/lib/webhooks/types.ts
@@ -1,3 +1,4 @@
+import {ValidationErrorReason, ValidationInvalid} from '../utils/types';
 import {AdapterArgs} from '../../runtime/types';
 import {Session} from '../session/session';
 
@@ -121,11 +122,13 @@ export interface WebhookProcessParams extends AdapterArgs {
 
 export interface WebhookValidateParams extends WebhookProcessParams {}
 
-export enum WebhookValidationErrorReason {
-  MissingHeaders = 'missing_headers',
-  MissingBody = 'missing_body',
-  InvalidHmac = 'invalid_hmac',
-}
+export const WebhookValidationErrorReason = {
+  ...ValidationErrorReason,
+  MissingHeaders: 'missing_headers',
+} as const;
+
+export type WebhookValidationErrorReasonType =
+  (typeof WebhookValidationErrorReason)[keyof typeof WebhookValidationErrorReason];
 
 export interface WebhookFields {
   webhookId: string;
@@ -136,14 +139,15 @@ export interface WebhookFields {
   subTopic?: string;
 }
 
-export interface WebhookValidationInvalid {
+export interface WebhookValidationInvalid
+  extends Omit<ValidationInvalid, 'reason'> {
   valid: false;
-  reason: WebhookValidationErrorReason;
+  reason: WebhookValidationErrorReasonType;
 }
 
 export interface WebhookValidationMissingHeaders
   extends WebhookValidationInvalid {
-  reason: WebhookValidationErrorReason.MissingHeaders;
+  reason: typeof WebhookValidationErrorReason.MissingHeaders;
   missingHeaders: string[];
 }
 

--- a/packages/shopify-api/lib/webhooks/validate.ts
+++ b/packages/shopify-api/lib/webhooks/validate.ts
@@ -18,6 +18,7 @@ import {
   WebhookValidationValid,
 } from './types';
 import {topicForStorage} from './registry';
+import { logger } from 'lib/logger';
 
 const OPTIONAL_HANDLER_PROPERTIES = {
   subTopic: ShopifyHeader.SubTopic,
@@ -55,6 +56,12 @@ export function validateFactory(config: ConfigInterface) {
           reason: WebhookValidationErrorReason.MissingHeaders,
           missingHeaders: [ShopifyHeader.Hmac],
         };
+      }
+      if (validHmacResult.reason === ValidationErrorReason.InvalidHmac) {
+        const log = logger(config);
+        await log.debug(
+          "Webhook HMAC validation failed. Please note that events manually triggered from a store's Notifications settings will fail this validation. To test this, please use the CLI or trigger the actual event in a development store.",
+        );
       }
       return validHmacResult;
     }

--- a/packages/shopify-api/lib/webhooks/validate.ts
+++ b/packages/shopify-api/lib/webhooks/validate.ts
@@ -1,3 +1,4 @@
+import {logger} from '../logger';
 import {validateHmacFromRequestFactory} from '../utils/hmac-validator';
 import {HmacValidationType, ValidationErrorReason} from '../utils/types';
 import {
@@ -18,7 +19,6 @@ import {
   WebhookValidationValid,
 } from './types';
 import {topicForStorage} from './registry';
-import { logger } from 'lib/logger';
 
 const OPTIONAL_HANDLER_PROPERTIES = {
   subTopic: ShopifyHeader.SubTopic,

--- a/packages/shopify-api/lib/webhooks/validate.ts
+++ b/packages/shopify-api/lib/webhooks/validate.ts
@@ -1,3 +1,5 @@
+import {validateHmacFromRequestFactory} from '../utils/hmac-validator';
+import {HmacValidationType, ValidationErrorReason} from '../utils/types';
 import {
   abstractConvertRequest,
   getHeader,
@@ -6,15 +8,14 @@ import {
 } from '../../runtime/http';
 import {ShopifyHeader} from '../types';
 import {ConfigInterface} from '../base-types';
-import {logger} from '../logger';
-import {validateHmacString} from '../utils/hmac-validator';
-import {HashFormat} from '../../runtime';
 
 import {
   WebhookFields,
   WebhookValidateParams,
   WebhookValidation,
   WebhookValidationErrorReason,
+  WebhookValidationMissingHeaders,
+  WebhookValidationValid,
 } from './types';
 import {topicForStorage} from './registry';
 
@@ -39,43 +40,32 @@ export function validateFactory(config: ConfigInterface) {
     const request: NormalizedRequest =
       await abstractConvertRequest(adapterArgs);
 
-    const log = logger(config);
+    const validHmacResult = await validateHmacFromRequestFactory(config)({
+      type: HmacValidationType.Webhook,
+      rawBody,
+      ...adapterArgs,
+    });
 
-    const webhookCheck = checkWebhookRequest(rawBody, request.headers);
-    if (!webhookCheck.valid) {
-      await log.debug('Received malformed webhook request', webhookCheck);
-      return webhookCheck;
+    if (!validHmacResult.valid) {
+      // Deprecated: this is for backwards compatibility with the old HMAC validation
+      // This will be removed in the next major version, and missing_hmac will be returned instead of missing_header when the hmac is missing
+      if (validHmacResult.reason === ValidationErrorReason.MissingHmac) {
+        return {
+          valid: false,
+          reason: WebhookValidationErrorReason.MissingHeaders,
+          missingHeaders: [ShopifyHeader.Hmac],
+        };
+      }
+      return validHmacResult;
     }
 
-    const {hmac, valid: _valid, ...loggingContext} = webhookCheck;
-    await log.debug('Webhook request is well formed', loggingContext);
-
-    if (await validateHmacString(config, rawBody, hmac, HashFormat.Base64)) {
-      await log.debug('Webhook request is valid', loggingContext);
-      return webhookCheck;
-    } else {
-      await log.debug(
-        "Webhook HMAC validation failed. Please note that events manually triggered from a store's Notifications settings will fail this validation. To test this, please use the CLI or trigger the actual event in a development store.",
-      );
-      return {
-        valid: false,
-        reason: WebhookValidationErrorReason.InvalidHmac,
-      };
-    }
+    return checkWebhookHeaders(request.headers);
   };
 }
 
-function checkWebhookRequest(
-  rawBody: string,
+function checkWebhookHeaders(
   headers: Headers,
-): WebhookValidation {
-  if (!rawBody.length) {
-    return {
-      valid: false,
-      reason: WebhookValidationErrorReason.MissingBody,
-    };
-  }
-
+): WebhookValidationMissingHeaders | WebhookValidationValid {
   const missingHeaders: ShopifyHeader[] = [];
   const entries = Object.entries(HANDLER_PROPERTIES) as [
     keyof WebhookFields,


### PR DESCRIPTION
### WHAT is this pull request doing?

* Flow, webhooks, and fulfillment services all validate the same way with hmac
* This pulls the common webhook validation into a reusable function

* ~Previously webhooks on returned invalid types `missing_body`, `missing_headers` and `invalid_hmac` now it will also return `missing_hmac` if the HMAC header specifically is missing. More closely aligning it to how flow works.~ We will keep the same functionality and change this at the next major version.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
