### PR TITLE
feat: add Shop.current method

### DIFF
--- a/packages/shopify-api/rest/admin/2024-01/shop.ts
+++ b/packages/shopify-api/rest/admin/2024-01/shop.ts
@@ -28,6 +28,23 @@ export class Shop extends Base {
     }
   ];
 
+  public static async current(
+    {
+      session,
+      fields = null,
+      ...otherArgs
+    }: AllArgs
+  ): Promise<Shop | null> {
+    const result = await this.baseFind<Shop>({
+      session: session,
+      urlIds: {},
+      params: {"fields": fields, ...otherArgs},
+    });
+
+    return result.data ? result.data[0] : null;
+  }
+
+
   public static async all(
     {
       session,


### PR DESCRIPTION
- close #1300

## Changelog

This PR adds the new method `Shop.current()` that behaves the same as `Shop.all()` with the exception of unwrapping the response to return only the `data[0]` object like the method `Customer.find()`.