### PR TITLE
Fix error handler in graphql client

### DIFF
--- a/.changeset/pretty-geese-look.md
+++ b/.changeset/pretty-geese-look.md
@@ -1,0 +1,7 @@
+---
+"@shopify/shopify-api": patch
+"@shopify/admin-api-client": patch
+"@shopify/graphql-client": patch
+---
+
+Fix type error in graphql error handler

--- a/packages/shopify-api/lib/auth/oauth/oauth.ts
+++ b/packages/shopify-api/lib/auth/oauth/oauth.ts
@@ -203,7 +203,7 @@ export function callback(config: ConfigInterface): OAuthCallback {
     );
 
     if (!postResponse.ok) {
-      throwFailedRequest(await postResponse.json(), postResponse, false);
+      throwFailedRequest(await postResponse.json(), false, postResponse);
     }
 
     const session: Session = createSession({

--- a/packages/shopify-api/lib/auth/oauth/token-exchange.ts
+++ b/packages/shopify-api/lib/auth/oauth/token-exchange.ts
@@ -60,7 +60,7 @@ export function tokenExchange(config: ConfigInterface): TokenExchange {
     );
 
     if (!postResponse.ok) {
-      throwFailedRequest(await postResponse.json(), postResponse, false);
+      throwFailedRequest(await postResponse.json(), false, postResponse);
     }
 
     return {

--- a/packages/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/shopify-api/lib/clients/admin/graphql/client.ts
@@ -124,13 +124,7 @@ export class GraphqlClient {
     if (response.errors) {
       const fetchResponse = response.errors.response;
 
-      if (!fetchResponse) {
-        throw new ShopifyErrors.GraphqlQueryError({
-          message: 'fetch api exception',
-          response: response as Record<string, any>,
-        });
-      }
-      throwFailedRequest(response, fetchResponse, (options?.retries ?? 0) > 0);
+      throwFailedRequest(response, (options?.retries ?? 0) > 0, fetchResponse);
     }
 
     return response;

--- a/packages/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/shopify-api/lib/clients/admin/graphql/client.ts
@@ -122,7 +122,14 @@ export class GraphqlClient {
     });
 
     if (response.errors) {
-      const fetchResponse = response.errors.response!;
+      const fetchResponse = response.errors.response;
+
+      if (!fetchResponse) {
+        throw new ShopifyErrors.GraphqlQueryError({
+          message: 'fetch api exception',
+          response: response as Record<string, any>,
+        });
+      }
       throwFailedRequest(response, fetchResponse, (options?.retries ?? 0) > 0);
     }
 

--- a/packages/shopify-api/lib/clients/admin/rest/client.ts
+++ b/packages/shopify-api/lib/clients/admin/rest/client.ts
@@ -172,7 +172,7 @@ export class RestClient {
     );
 
     if (!response.ok) {
-      throwFailedRequest(body, response, (params.tries ?? 1) > 1);
+      throwFailedRequest(body, (params.tries ?? 1) > 1, response);
     }
 
     const requestReturn: RestRequestReturn<T> = {

--- a/packages/shopify-api/lib/clients/common.ts
+++ b/packages/shopify-api/lib/clients/common.ts
@@ -58,9 +58,18 @@ export function clientLoggerFactory(config: ConfigInterface) {
 
 export function throwFailedRequest(
   body: any,
-  response: Response,
   atMaxRetries: boolean,
+  response?: Response,
 ): never {
+  if (typeof response === 'undefined') {
+    throw new ShopifyErrors.HttpRequestError(
+      'Http request error, no response available',
+      {
+        body,
+      },
+    );
+  }
+
   const responseHeaders = canonicalizeHeaders(
     Object.fromEntries(response.headers.entries() ?? []),
   );

--- a/packages/shopify-api/lib/clients/storefront/client.ts
+++ b/packages/shopify-api/lib/clients/storefront/client.ts
@@ -137,8 +137,9 @@ export class StorefrontClient {
     });
 
     if (response.errors) {
-      const fetchResponse = response.errors.response!;
-      throwFailedRequest(response, fetchResponse, (options?.retries ?? 0) > 0);
+      const fetchResponse = response.errors.response;
+
+      throwFailedRequest(response, (options?.retries ?? 0) > 0, fetchResponse);
     }
 
     return response;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

In some cases, fetch response is not available for error handling, so type error appears:

```
TypeError: Cannot read properties of undefined (reading 'headers')
```


Related issues: #1201

<!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

In case of `response` object is not avaliabe `GraphqlQueryError` is raised directly with outer response data.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
