### PR TITLE
Fix changeset for shopify-api

### DIFF
--- a/.changeset/pretty-geese-look.md
+++ b/.changeset/pretty-geese-look.md
@@ -1,7 +1,5 @@
 ---
 "@shopify/shopify-api": patch
-"@shopify/admin-api-client": patch
-"@shopify/graphql-client": patch
 ---
 
 Fix type error in graphql error handler


### PR DESCRIPTION
Just tweaking a changeset that was including packages that weren't affected by #1330 - all of the changes in that PR were in `shopify-api`.